### PR TITLE
publish version 2.1.22

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTIL:
 
 BUGFIX:
 * type=service actions=move | bugfix to not error out if pre-defined service object service-http/-https must be merged with an existing object of same name
+* type=tag-merger | bugfix if dupalgorithm=samename
 
 GENERAL:
 * general | dynamic content update to version 8776-8390

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTIL:
 BUGFIX:
 
 GENERAL:
+* general | dynamic content update to version 8775-8381
 
 
 2.1.21  (20231107)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ BUGFIX:
 * type=tag-merger | bugfix if dupalgorithm=samename
 * type=address actions=move | bugfix for tag object search
 * type=rule | different actions - if last object of src/dst/srv/urlcategory is removed, and if not force any is used, rule will be disabled
+* type=device actions=display-shadowrule loadpanoramapushedconfig | extend validation as panoramapushedconfig check is not implemented
 
 GENERAL:
 * general | dynamic content update to version 8776-8390

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,14 @@
 CHANGELOG
 
-2.1.21
+2.1.22
+UTIL:
+
+BUGFIX:
+
+GENERAL:
+
+
+2.1.21  (20231107)
 UTIL:
 * type=certificate actions=exporttoexcel:FILE.html | improvement to display correct Template / Location if certificate is configured in Panorama Template vsys
 * type=XYZ-merger | extend with skipped reason for HTML spreadsheet

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ BUGFIX:
 * type=device actions=display-shadowrule loadpanoramapushedconfig | extend validation as panoramapushedconfig check is not implemented
 * type=rule actions=from-remove-from-file/to-remove-from-file | bugfix as wrong from/to zone are removed
 * class NAT | bugfix of none correct variable name $connector
+* type=service-merger | bugfix for exportcsv=file.html to add also deleted objects where an ancestor at upperlevel is available
 
 GENERAL:
 * general | dynamic content update to version 8776-8390

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,7 +6,7 @@ UTIL:
 BUGFIX:
 
 GENERAL:
-* general | dynamic content update to version 8775-8381
+* general | dynamic content update to version 8776-8390
 
 
 2.1.21  (20231107)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ BUGFIX:
 * type=rule | different actions - if last object of src/dst/srv/urlcategory is removed, and if not force any is used, rule will be disabled
 * type=device actions=display-shadowrule loadpanoramapushedconfig | extend validation as panoramapushedconfig check is not implemented
 * type=rule actions=from-remove-from-file/to-remove-from-file | bugfix as wrong from/to zone are removed
+* class NAT | bugfix of none correct variable name $connector
 
 GENERAL:
 * general | dynamic content update to version 8776-8390

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ BUGFIX:
 * type=address actions=move | bugfix for tag object search
 * type=rule | different actions - if last object of src/dst/srv/urlcategory is removed, and if not force any is used, rule will be disabled
 * type=device actions=display-shadowrule loadpanoramapushedconfig | extend validation as panoramapushedconfig check is not implemented
+* type=rule actions=from-remove-from-file/to-remove-from-file | bugfix as wrong from/to zone are removed
 
 GENERAL:
 * general | dynamic content update to version 8776-8390

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTIL:
 BUGFIX:
 * type=service actions=move | bugfix to not error out if pre-defined service object service-http/-https must be merged with an existing object of same name
 * type=tag-merger | bugfix if dupalgorithm=samename
+* type=address actions=move | bugfix for tag object search
 
 GENERAL:
 * general | dynamic content update to version 8776-8390

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,7 +15,7 @@ BUGFIX:
 * type=service-merger | bugfix for exportcsv=file.html to add also deleted objects where an ancestor at upperlevel is available
 
 GENERAL:
-* general | dynamic content update to version 8776-8390
+* update to Device App-ID version: 8785-8431
 
 
 2.1.21  (20231107)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ CHANGELOG
 
 2.1.22
 UTIL:
+* type=rule actions=XYZ | improve error handling
 
 BUGFIX:
 * type=service actions=move | bugfix to not error out if pre-defined service object service-http/-https must be merged with an existing object of same name

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ BUGFIX:
 * type=service actions=move | bugfix to not error out if pre-defined service object service-http/-https must be merged with an existing object of same name
 * type=tag-merger | bugfix if dupalgorithm=samename
 * type=address actions=move | bugfix for tag object search
+* type=rule | different actions - if last object of src/dst/srv/urlcategory is removed, and if not force any is used, rule will be disabled
 
 GENERAL:
 * general | dynamic content update to version 8776-8390

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTIL:
 
 BUGFIX:
+* type=service actions=move | bugfix to not error out if pre-defined service object service-http/-https must be merged with an existing object of same name
 
 GENERAL:
 * general | dynamic content update to version 8776-8390

--- a/lib/container-classes/AddressRuleContainer.php
+++ b/lib/container-classes/AddressRuleContainer.php
@@ -133,12 +133,15 @@ class AddressRuleContainer extends ObjRuleContainer
 
         if( $ret && $count == 1 && !$forceAny )
         {
+            $this->owner->setDisabled(true);
+            /*
             $string = "you are trying to remove last Object from a rule which will set it to ANY, please use forceAny=true for object: " . $this->toString();
             if( $context === null )
                 derr( $string );
 
             PH::ACTIONstatus( $context, 'skipped', $string);
             return false;
+            */
         }
 
         if( $ret && $rewriteXml )

--- a/lib/container-classes/ServiceRuleContainer.php
+++ b/lib/container-classes/ServiceRuleContainer.php
@@ -103,8 +103,9 @@ class ServiceRuleContainer extends ObjRuleContainer
 
         if( $ret && $count == 1 && !$forceAny )
         {
-            derr("you are trying to remove last Object from a rule which will set it to ANY, please use forceAny=true for object: "
-                . $this->toString());
+            $this->owner->setDisabled(true);
+            #derr("you are trying to remove last Object from a rule which will set it to ANY, please use forceAny=true for object: "
+            #    . $this->toString());
         }
 
         if( $ret && $rewriteXml )

--- a/lib/container-classes/UrlCategoryRuleContainer.php
+++ b/lib/container-classes/UrlCategoryRuleContainer.php
@@ -92,8 +92,9 @@ class UrlCategoryRuleContainer extends ObjRuleContainer
 
         if( $ret && $count == 1 && !$forceAny )
         {
-            derr("you are trying to remove last Object from a rule which will set it to ANY, please use forceAny=true for object: "
-                . $this->toString());
+            $this->owner->setDisabled(true);
+            #derr("you are trying to remove last Object from a rule which will set it to ANY, please use forceAny=true for object: "
+            #    . $this->toString());
         }
 
         if( $ret && $rewriteXml )

--- a/lib/device-and-system-classes/PANConf.php
+++ b/lib/device-and-system-classes/PANConf.php
@@ -741,6 +741,7 @@ class PANConf
      */
     public function findVirtualSystem($name)
     {
+        //what about 'panoramaPushedConfig'
         foreach( $this->virtualSystems as $vsys )
         {
             if( $vsys->name() == $name )

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -192,7 +192,7 @@ class PH
 
     private static $library_version_major = 2;
     private static $library_version_sub = 1;
-    private static $library_version_bugfix = 21;
+    private static $library_version_bugfix = 22;
 
     //BASIC AUTH PAN-OS 7.1
     public static $softwareupdate_key = "658d787f293e631196dac9fb29490f1cc1bb3827";

--- a/lib/object-classes/Service.php
+++ b/lib/object-classes/Service.php
@@ -490,7 +490,13 @@ class Service
     public function protocol()
     {
         if( $this->isTmpSrv() )
+        {
+            if( $this->name() == 'service-http' )
+                return 'tcp';
+            if( $this->name() == 'service-https' )
+                return 'tcp';
             return 'tmp';
+        }
 
         else
             return $this->_protocol;
@@ -622,11 +628,18 @@ class Service
 
     public function sameValue(Service $otherObject)
     {
-        if( $this->isTmpSrv() && !$otherObject->isTmpSrv() )
-            return FALSE;
+        if( $otherObject->name() == "service-http" && $this->name() == "service-http" )
+        {}
+        elseif( $otherObject->name() == "service-https" && $this->name() == "service-https" )
+        {}
+        else
+        {
+            if( $this->isTmpSrv() && !$otherObject->isTmpSrv() )
+                return FALSE;
 
-        if( $otherObject->isTmpSrv() && !$this->isTmpSrv() )
-            return FALSE;
+            if( $otherObject->isTmpSrv() && !$this->isTmpSrv() )
+                return FALSE;
+        }
 
         if( $otherObject->_protocol !== $this->_protocol )
             return FALSE;

--- a/lib/rule-classes/NatRule.php
+++ b/lib/rule-classes/NatRule.php
@@ -470,7 +470,7 @@ class NatRule extends Rule
             $con = findConnectorOrDie($this);
 
             if( $con->isAPI() )
-                $connector->sendEditRequest($xpath, DH::dom_to_xml($this->dnatroot, -1, FALSE), TRUE);
+                $con->sendEditRequest($xpath, DH::dom_to_xml($this->dnatroot, -1, FALSE), TRUE);
 
             return TRUE;
         }

--- a/utils/bash_autocompletion/pan-os-php.sh
+++ b/utils/bash_autocompletion/pan-os-php.sh
@@ -59,7 +59,8 @@ __pan-os-php_scripts()
 
 		arguments=('type=' 'in=' 'out=' 'actions=' 'filter=' 'location=' 'loadpanoramapushedconfig' 'loadplugin=' 'help'
 		 'listactions' 'listfilters' 'debugapi' 'apitimeout='
-		 'shadow-apikeyhidden' 'shadow-apikeynohidden' 'shadow-apikeynosave' 'shadow-disableoutputformatting' 'shadow-displaycurlrequest' 'shadow-enablexmlduplicatesdeletion'
+		 'shadow-apikeyhidden' 'shadow-apikeynohidden' 'shadow-apikeynosave' 'shadow-disableoutputformatting' 'shadow-displaycurlrequest'
+		 'shadow-enablexmlduplicatesdeletion'
 		 'shadow-ignoreinvalidaddressobjects' 'shadow-json' 'shadow-reducexml'
 		 'outputformatset='
 		 'stats' 'template=' 'version' )

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -1550,7 +1550,7 @@ AddressCallContext::$supportedActions[] = array(
             {
                 foreach( $object->tags->getAll() as $tag )
                 {
-                    if( $targetStore->find($tag->name(), null, true ) === null )
+                    if( $findSubSystem->tagStore->find($tag->name(), null, true ) === null )
                     {
                         $string = "this address object has a tag named '{$tag->name()} that does not exist in target location '{$targetLocation}'";
                         PH::ACTIONstatus( $context, "SKIPPED", $string );

--- a/utils/common/actions-device.php
+++ b/utils/common/actions-device.php
@@ -1493,7 +1493,13 @@ DeviceCallContext::$supportedActions['display-shadowrule'] = array(
                         }
                         elseif( $classtype == "VirtualSystem" )
                         {
-                            $sub = $pan->findVirtualSystem( $ownerDG );
+                            if( $ownerDG === "panoramaPushedConfig" )
+                            {
+                                derr( "shadow Rule check on FW with panoramaPushedConfig is not implemented", null, FALSE );
+                            }
+                            else
+                                $sub = $pan->findVirtualSystem( $ownerDG );
+
                             $shadowedRuleObj = $sub->$ruletype->find( $shadow2 );
                             if( $shadowedRuleObj === null )
                             {

--- a/utils/common/actions-rule.php
+++ b/utils/common/actions-rule.php
@@ -774,9 +774,9 @@ RuleCallContext::$supportedActions[] = array(
 
 
             if( $context->isAPI )
-                $rule->to->API_removeZone($objectFind);
+                $rule->from->API_removeZone($objectFind);
             else
-                $rule->to->removeZone($objectFind);
+                $rule->from->removeZone($objectFind);
         }
 
     },
@@ -1024,7 +1024,7 @@ RuleCallContext::$supportedActions[] = array(
             }
             */
 
-            $objectFind = $rule->from->parentCentralStore->find($zone);
+            $objectFind = $rule->to->parentCentralStore->find($zone);
             if( $objectFind === null )
             {
                 mwarning("zone named '{$zone}' not found");

--- a/utils/common/actions-rule.php
+++ b/utils/common/actions-rule.php
@@ -4222,6 +4222,31 @@ RuleCallContext::$supportedActions[] = array(
                 derr("cannot find vsys or device group named '{$location}'");
             $ruleStore = $sub->$variableName;
         }
+
+        $owner = $rule->owner->owner;
+        $found = false;
+        if( $pan->isPanorama() )
+        {
+            /** @var DeviceGroup $owner */
+            $childDGs = $owner->childDeviceGroups(TRUE);
+            foreach( $childDGs as $DG )
+            {
+                if( $DG->name() == $location )
+                    $found = true;
+            }
+        }
+
+        if( !$found )
+        {
+            //Todo: validation needed if specific objects used in rule are available:
+            #print "check needed\n";
+            //$addressStore = $owner->addressStore
+            //$serviceStore = $owner->serviceStore
+            //$tagStore = $owner->tagStore
+            //securityprofile/securityProfilegroup
+            //urlcategory
+        }
+
         if( $context->isAPI )
         {
             if( $ruleStore === $rule->owner )

--- a/utils/common/actions-rule.php
+++ b/utils/common/actions-rule.php
@@ -66,10 +66,10 @@ RuleCallContext::$commonActionFunctions['calculate-zones'] = array(
                     $panorama = $system->owner;
 
                 if( $context->arguments['template'] == $context->actionRef['args']['template']['default'] )
-                    derr('with Panorama configs, you need to specify a template name');
+                    derr('with Panorama configs, you need to specify a template name', null, FALSE);
 
                 if( $context->arguments['virtualRouter'] == $context->actionRef['args']['virtualRouter']['default'] )
-                    derr('with Panorama configs, you need to specify virtualRouter argument. Available virtual routes are: ');
+                    derr('with Panorama configs, you need to specify virtualRouter argument. Available virtual routes are: ', null, FALSE);
 
                 $_tmp_explTemplateName = explode('@', $context->arguments['template']);
                 if( count($_tmp_explTemplateName) > 1 )
@@ -123,7 +123,7 @@ RuleCallContext::$commonActionFunctions['calculate-zones'] = array(
                 {
                     $template = $panorama->findTemplate($context->arguments['template']);
                     if( $template === null )
-                        derr("cannot find Template named '{$context->arguments['template']}'. Available template list:" . PH::list_to_string($panorama->templates));
+                        derr("cannot find Template named '{$context->arguments['template']}'. Available template list:" . PH::list_to_string($panorama->templates), null, FALSE);
                 }
 
                 if( $configIsOnLocalFirewall )
@@ -138,7 +138,7 @@ RuleCallContext::$commonActionFunctions['calculate-zones'] = array(
                     else
                         $tmpVar = $template->deviceConfiguration->network->virtualRouterStore->virtualRouters();
 
-                    derr("cannot find VirtualRouter named '{$context->arguments['virtualRouter']}' in Template '{$context->arguments['template']}'. Available VR list: " . PH::list_to_string($tmpVar));
+                    derr("cannot find VirtualRouter named '{$context->arguments['virtualRouter']}' in Template '{$context->arguments['template']}'. Available VR list: " . PH::list_to_string($tmpVar), null, FALSE);
                 }
 
                 if( (!$configIsOnLocalFirewall && count($template->deviceConfiguration->virtualSystems) == 1) || ($configIsOnLocalFirewall && count($firewall->virtualSystems) == 1) )
@@ -157,7 +157,7 @@ RuleCallContext::$commonActionFunctions['calculate-zones'] = array(
                     }
                     elseif( $context->arguments['vsys'] == '*autodetermine*' )
                     {
-                        derr("cannot autodetermine resolution context from Template '{$context->arguments['template']}' VR '{$context->arguments['virtualRouter']}'' , multiple VSYS are available: " . PH::list_to_string($vsysConcernedByVR) . ". Please provide choose a VSYS.");
+                        derr("cannot autodetermine resolution context from Template '{$context->arguments['template']}' VR '{$context->arguments['virtualRouter']}'' , multiple VSYS are available: " . PH::list_to_string($vsysConcernedByVR) . ". Please provide choose a VSYS.", null, FALSE);
                     }
                     else
                     {
@@ -166,7 +166,7 @@ RuleCallContext::$commonActionFunctions['calculate-zones'] = array(
                         else
                             $vsys = $template->deviceConfiguration->findVirtualSystem($context->arguments['vsys']);
                         if( $vsys === null )
-                            derr("cannot find VSYS '{$context->arguments['vsys']}' in Template '{$context->arguments['template']}'");
+                            derr("cannot find VSYS '{$context->arguments['vsys']}' in Template '{$context->arguments['template']}'", null, FALSE);
                         $system = $vsys;
                     }
                 }
@@ -179,7 +179,7 @@ RuleCallContext::$commonActionFunctions['calculate-zones'] = array(
             {
                 $virtualRouterToProcess = $system->owner->network->virtualRouterStore->findVirtualRouter($context->arguments['virtualRouter']);
                 if( $virtualRouterToProcess === null )
-                    derr("VirtualRouter named '{$context->arguments['virtualRouter']}' not found");
+                    derr("VirtualRouter named '{$context->arguments['virtualRouter']}' not found", null, FALSE);
             }
             else
             {
@@ -201,9 +201,9 @@ RuleCallContext::$commonActionFunctions['calculate-zones'] = array(
                 $string = "VSYS/DG '{$system->name()}' has interfaces attached to " . count($foundRouters) . " virtual routers";
                 PH::ACTIONlog($context, $string);
                 if( count($foundRouters) > 1 )
-                    derr("more than 1 suitable virtual routers found, please specify one fo the following: " . PH::list_to_string($foundRouters));
+                    derr("more than 1 suitable virtual routers found, please specify one fo the following: " . PH::list_to_string($foundRouters), null, FALSE);
                 if( count($foundRouters) == 0 )
-                    derr("no suitable VirtualRouter found, please force one or check your configuration");
+                    derr("no suitable VirtualRouter found, please force one or check your configuration", null, FALSE);
 
                 $virtualRouterToProcess = $foundRouters[0];
             }
@@ -421,7 +421,7 @@ RuleCallContext::$commonActionFunctions['calculate-zones'] = array(
 
                 if( $rule->isNatRule() && $fromOrTo == 'to' )
                 {
-                    derr($context->padding . ' NAT rules are not supported yet');
+                    derr($context->padding . ' NAT rules are not supported yet', null, FALSE);
                 }
 
                 if( $fromOrTo == 'from' )
@@ -496,7 +496,7 @@ RuleCallContext::$commonActionFunctions['zone-add'] = array(
 
         $objectFind = $zoneContainer->parentCentralStore->findOrCreate($context->arguments['zoneName']);
         if( $objectFind === null )
-            derr("zone named '{$context->arguments['zoneName']}' not found");
+            derr("zone named '{$context->arguments['zoneName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $zoneContainer->API_addZone($objectFind);
@@ -551,7 +551,7 @@ RuleCallContext::$commonActionFunctions['zone-replace'] = array(
 
         $zoneToReplace = $zoneContainer->parentCentralStore->find($zoneNameToReplace);
         if( $zoneToReplace === null )
-            derr("zone '{$zoneNameToReplace}' does not exist. If it's intended then please use a REGEXP instead\n");
+            derr("zone '{$zoneNameToReplace}' does not exist. If it's intended then please use a REGEXP instead\n", null, False);
 
         if( !$zoneContainer->hasZone($zoneToReplace) )
         {
@@ -564,7 +564,7 @@ RuleCallContext::$commonActionFunctions['zone-replace'] = array(
         if( $zoneForReplacement === null )
         {
             if( !$force )
-                derr("zone '{$zoneNameForReplacement}' does not exist. If it's intended then please use option force=TRUE to bypass this safeguard");
+                derr("zone '{$zoneNameForReplacement}' does not exist. If it's intended then please use option force=TRUE to bypass this safeguard", null, false);
             $zoneForReplacement = $zoneContainer->parentCentralStore->createTmp($zoneNameForReplacement);
         }
 
@@ -698,7 +698,7 @@ RuleCallContext::$supportedActions[] = array(
 
         $objectFind = $rule->from->parentCentralStore->find($context->arguments['zoneName']);
         if( $objectFind === null )
-            derr("zone named '{$context->arguments['zoneName']}' not found");
+            derr("zone named '{$context->arguments['zoneName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $rule->from->API_removeZone($objectFind);
@@ -810,7 +810,7 @@ RuleCallContext::$supportedActions[] = array(
 
         $objectFind = $rule->from->parentCentralStore->find($context->arguments['zoneName']);
         if( $objectFind === null )
-            derr("zone named '{$context->arguments['zoneName']}' not found");
+            derr("zone named '{$context->arguments['zoneName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $rule->from->API_removeZone($objectFind, TRUE, TRUE);
@@ -957,7 +957,7 @@ RuleCallContext::$supportedActions[] = array(
 
         $objectFind = $rule->from->parentCentralStore->find($context->arguments['zoneName']);
         if( $objectFind === null )
-            derr("zone named '{$context->arguments['zoneName']}' not found");
+            derr("zone named '{$context->arguments['zoneName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $rule->to->API_removeZone($objectFind);
@@ -1073,7 +1073,7 @@ RuleCallContext::$supportedActions[] = array(
 
         $objectFind = $rule->from->parentCentralStore->find($context->arguments['zoneName']);
         if( $objectFind === null )
-            derr("zone named '{$context->arguments['zoneName']}' not found");
+            derr("zone named '{$context->arguments['zoneName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $rule->to->API_removeZone($objectFind, TRUE, TRUE);
@@ -1313,13 +1313,13 @@ RuleCallContext::$supportedActions[] = array(
 
         if( !isset($context->nestedQueries[$queryName]) )
         {
-            derr("cannot find query filter called '{$queryName}'");
+            derr("cannot find query filter called '{$queryName}'", null, FALSE);
         }
 
         $rQuery = new RQuery('address');
         $errorMessage = '';
         if( !$rQuery->parseFromString($context->nestedQueries[$queryName], $errorMessage) )
-            derr("error while parsing query: {$context->nestedQueries[$queryName]}");
+            derr("error while parsing query: {$context->nestedQueries[$queryName]}", null, FALSE);
 
 
         foreach( $rule->source->members() as $member )
@@ -1424,13 +1424,13 @@ RuleCallContext::$supportedActions[] = array(
 
         if( !isset($context->nestedQueries[$queryName]) )
         {
-            derr("cannot find query filter called '{$queryName}'");
+            derr("cannot find query filter called '{$queryName}'", null, FALSE);
         }
 
         $rQuery = new RQuery('address');
         $errorMessage = '';
         if( !$rQuery->parseFromString($context->nestedQueries[$queryName], $errorMessage) )
-            derr("error while parsing query: {$context->nestedQueries[$queryName]}\nError Message is: {$errorMessage}\n");
+            derr("error while parsing query: {$context->nestedQueries[$queryName]}\nError Message is: {$errorMessage}\n", null, FALSE);
 
 
         foreach( $rule->destination->members() as $member )
@@ -1483,13 +1483,13 @@ RuleCallContext::$supportedActions[] = array(
 
         if( !isset($context->nestedQueries[$queryName]) )
         {
-            derr("cannot find query filter called '{$queryName}'");
+            derr("cannot find query filter called '{$queryName}'", null, FALSE);
         }
 
         $rQuery = new RQuery('service');
         $errorMessage = '';
         if( !$rQuery->parseFromString($context->nestedQueries[$queryName], $errorMessage) )
-            derr("error while parsing query: {$context->nestedQueries[$queryName]}\nError Message is: {$errorMessage}\n");
+            derr("error while parsing query: {$context->nestedQueries[$queryName]}\nError Message is: {$errorMessage}\n", null, FALSE);
 
 
         foreach( $rule->services->members() as $member )
@@ -1669,7 +1669,7 @@ RuleCallContext::$supportedActions[] = array(
         }
         $objectFind = $rule->source->parentCentralStore->find($context->arguments['objName']);
         if( $objectFind === null )
-            derr("address-type object named '{$context->arguments['objName']}' not found");
+            derr("address-type object named '{$context->arguments['objName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $rule->destination->API_remove($objectFind, TRUE);
@@ -1765,7 +1765,7 @@ RuleCallContext::$supportedActions[] = array(
         $rule = $context->object;
         $objectFind = $rule->tags->parentCentralStore->find($context->arguments['tagName']);
         if( $objectFind === null )
-            derr("tag named '{$context->arguments['tagName']}' not found");
+            derr("tag named '{$context->arguments['tagName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $rule->tags->API_addTag($objectFind);
@@ -1810,7 +1810,7 @@ RuleCallContext::$supportedActions[] = array(
         $rule = $context->object;
         $objectFind = $rule->tags->parentCentralStore->find($context->arguments['tagName']);
         if( $objectFind === null )
-            derr("tag named '{$context->arguments['tagName']}' not found");
+            derr("tag named '{$context->arguments['tagName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $rule->tags->API_removeTag($objectFind);
@@ -1847,7 +1847,7 @@ RuleCallContext::$supportedActions[] = array(
         {
             $result = preg_match($pattern, $tag->name());
             if( $result === FALSE )
-                derr("'$pattern' is not a valid regex");
+                derr("'$pattern' is not a valid regex", null, FALSE);
             if( $result == 1 )
             {
                 $string = "removing tag {$tag->name()}... ";
@@ -1934,7 +1934,7 @@ RuleCallContext::$supportedActions[] = array(
         }
         $objectFind = $rule->services->parentCentralStore->find($context->arguments['svcName']);
         if( $objectFind === null )
-            derr("service named '{$context->arguments['svcName']}' not found");
+            derr("service named '{$context->arguments['svcName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $rule->services->API_add($objectFind);
@@ -1956,7 +1956,7 @@ RuleCallContext::$supportedActions[] = array(
         }
         $objectFind = $rule->services->parentCentralStore->find($context->arguments['svcName']);
         if( $objectFind === null )
-            derr("service named '{$context->arguments['svcName']}' not found");
+            derr("service named '{$context->arguments['svcName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $rule->services->API_remove($objectFind);
@@ -1978,7 +1978,7 @@ RuleCallContext::$supportedActions[] = array(
         }
         $objectFind = $rule->services->parentCentralStore->find($context->arguments['svcName']);
         if( $objectFind === null )
-            derr("service named '{$context->arguments['svcName']}' not found");
+            derr("service named '{$context->arguments['svcName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $rule->services->API_remove($objectFind, TRUE, TRUE);
@@ -2032,7 +2032,7 @@ RuleCallContext::$supportedActions[] = array(
 
         $objectFind = $rule->apps->parentCentralStore->find($appName);
         if( $objectFind === null )
-            derr("application named '{$appName}' not found");
+            derr("application named '{$appName}' not found", null, FALSE);
 
         $string = "adding application '{$appName}'... ";
         PH::ACTIONlog( $context, $string );
@@ -2057,7 +2057,7 @@ RuleCallContext::$supportedActions[] = array(
         }
         $objectFind = $rule->apps->parentCentralStore->findorCreate($context->arguments['appName']);
         if( $objectFind === null )
-            derr("application named '{$context->arguments['appName']}' not found");
+            derr("application named '{$context->arguments['appName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $rule->apps->API_addApp($objectFind);
@@ -2079,7 +2079,7 @@ RuleCallContext::$supportedActions[] = array(
         }
         $objectFind = $rule->apps->parentCentralStore->find($context->arguments['appName']);
         if( $objectFind === null )
-            derr("application named '{$context->arguments['appName']}' not found");
+            derr("application named '{$context->arguments['appName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $rule->apps->API_removeApp($objectFind);
@@ -2101,7 +2101,7 @@ RuleCallContext::$supportedActions[] = array(
         }
         $objectFind = $rule->apps->parentCentralStore->find($context->arguments['appName']);
         if( $objectFind === null )
-            derr("application named '{$context->arguments['appName']}' not found");
+            derr("application named '{$context->arguments['appName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $rule->apps->API_removeApp($objectFind, TRUE, TRUE);
@@ -3157,7 +3157,7 @@ RuleCallContext::$supportedActions[] = array(
             return;
         }
         if( !$context->isAPI )
-            derr('you cannot call this action without API mode');
+            derr('you cannot call this action without API mode', null, FALSE);
 
         if( $rule->setEnabled($context->arguments['trueOrFalse']) )
         {
@@ -3199,7 +3199,7 @@ RuleCallContext::$supportedActions[] = array(
             return;
         }
         if( !$context->isAPI )
-            derr('you cannot call this action without API mode');
+            derr('you cannot call this action without API mode', null, FALSE);
 
         if( $rule->setDisabled($context->arguments['trueOrFalse']) )
         {
@@ -3271,7 +3271,7 @@ RuleCallContext::$supportedActions[] = array(
         }
 
         if( !$context->isAPI )
-            derr('you cannot call this action without API mode');
+            derr('you cannot call this action without API mode', null, FALSE);
 
         if( $rule->setDsri($context->arguments['trueOrFalse']) )
         {
@@ -3366,7 +3366,7 @@ RuleCallContext::$supportedActions[] = array(
 
         $objectFind = $rule->source->parentCentralStore->find($context->arguments['objName']);
         if( $objectFind === null )
-            derr("address-type object named '{$context->arguments['objName']}' not found");
+            derr("address-type object named '{$context->arguments['objName']}' not found", null, FALSE);
 
         if( $context->isAPI )
             $rule->API_setDNAT( $objectFind, null, $dnattype  );
@@ -4164,7 +4164,7 @@ RuleCallContext::$supportedActions[] = array(
         if( strtolower($location) == 'shared' )
         {
             if( $pan->isFirewall() )
-                derr("Rules cannot be copied to SHARED location on a firewall, only in Panorama");
+                derr("Rules cannot be copied to SHARED location on a firewall, only in Panorama", null, FALSE);
 
             $ruleStore = $pan->$variableName;
         }
@@ -4172,7 +4172,7 @@ RuleCallContext::$supportedActions[] = array(
         {
             $sub = $pan->findSubSystemByName($location);
             if( $sub === null )
-                derr("cannot find vsys or device group named '{$location}'");
+                derr("cannot find vsys or device group named '{$location}'", null, FALSE);
             $ruleStore = $sub->$variableName;
         }
         if( $context->isAPI )
@@ -4211,7 +4211,7 @@ RuleCallContext::$supportedActions[] = array(
         if( strtolower($location) == 'shared' )
         {
             if( $pan->isFirewall() )
-                derr("Rules cannot be moved to SHARED location on a firewall, only in Panorama");
+                derr("Rules cannot be moved to SHARED location on a firewall, only in Panorama", null, FALSE);
 
             $ruleStore = $pan->$variableName;
         }
@@ -4219,7 +4219,7 @@ RuleCallContext::$supportedActions[] = array(
         {
             $sub = $pan->findSubSystemByName($location);
             if( $sub === null )
-                derr("cannot find vsys or device group named '{$location}'");
+                derr("cannot find vsys or device group named '{$location}'", null, FALSE);
             $ruleStore = $sub->$variableName;
         }
 
@@ -4835,13 +4835,13 @@ RuleCallContext::$supportedActions[] = array(
                 $listOfServicesQueryName = substr($context->arguments['restrictToListOfServices'], 1);
                 if( !isset($context->nestedQueries[$listOfServicesQueryName]) )
                 {
-                    derr("cannot find query filter called '$listOfServicesQueryName'");
+                    derr("cannot find query filter called '$listOfServicesQueryName'", null, FALSE);
                 }
 
                 $rQuery = new RQuery('service');
                 $errorMessage = '';
                 if( !$rQuery->parseFromString($context->nestedQueries[$listOfServicesQueryName], $errorMessage) )
-                    derr("error while parsing query: {$context->nestedQueries[$listOfServicesQueryName]}");
+                    derr("error while parsing query: {$context->nestedQueries[$listOfServicesQueryName]}", null, FALSE);
 
                 $services = array();
 
@@ -5072,7 +5072,7 @@ RuleCallContext::$supportedActions[] = Array(
             $text = file_get_contents( $context->arguments['file'] );
 
             if( $text === false )
-                derr("cannot open file '{$context->arguments['file']}");
+                derr("cannot open file '{$context->arguments['file']}", null, FALSE);
 
             $lines = explode("\n", $text);
             foreach( $lines as  $line)
@@ -5095,7 +5095,7 @@ RuleCallContext::$supportedActions[] = Array(
             $tmpUser = explode(",", $entry);
             if( count( $tmpUser ) !== 2 )
             {
-                derr( "file syntax: 'old-user-name,newusername'" );
+                derr( "file syntax: 'old-user-name,newusername'", null, FALSE);
             }
 
             $oldUserName = trim($tmpUser[0]);
@@ -5187,7 +5187,7 @@ RuleCallContext::$supportedActions[] = Array(
             {
                 $context->ldapbind = ldap_bind($context->ldapconn, $ldapUser, $ldapPassword);
                 if( !$context->ldapbind )
-                    derr( "LDAP connection not working" );
+                    derr( "LDAP connection not working", null, FALSE);
             }
             $context->first = false;
         }
@@ -5852,7 +5852,7 @@ RuleCallContext::$supportedActions[] = Array(
             }
         }
         else
-            derr( 'only supported in API mode' );
+            derr( 'only supported in API mode', null, FALSE);
     },
     'args' => Array( 'logHistory' => Array( 'type' => 'string', 'default' => 'last-15-minutes' ) ),
     'help' => 'returns TRUE if rule name matches the specified timestamp MM/DD/YYYY [american] / DD-MM-YYYY [european] / 21 September 2021 / -90 days',
@@ -5895,7 +5895,7 @@ RuleCallContext::$supportedActions[] = Array(
             }
         }
         else
-            derr( 'only supported in API mode' );
+            derr( 'only supported in API mode', null, FALSE);
     },
     'args' => Array( 'logHistory' => Array( 'type' => 'string', 'default' => 'last-15-minutes' ) ),
     'help' => 'returns TRUE if rule name matches the specified timestamp MM/DD/YYYY [american] / DD-MM-YYYY [european] / 21 September 2021 / -90 days',
@@ -5933,7 +5933,7 @@ RuleCallContext::$supportedActions[] = Array(
             }
         }
         else
-            derr( 'only supported in API mode' );
+            derr( 'only supported in API mode', null, FALSE);
     },
     'args' => Array( 'logHistory' => Array( 'type' => 'string', 'default' => 'last-15-minutes' ) ),
     'help' => 'returns TRUE if rule name matches the specified timestamp MM/DD/YYYY [american] / DD-MM-YYYY [european] / 21 September 2021 / -90 days',
@@ -5971,7 +5971,7 @@ RuleCallContext::$supportedActions[] = Array(
             }
         }
         else
-            derr( 'only supported in API mode' );
+            derr( 'only supported in API mode', null, FALSE);
     },
     'args' => Array( 'logHistory' => Array( 'type' => 'string', 'default' => 'last-15-minutes' ) ),
     'help' => 'returns TRUE if rule name matches the specified timestamp MM/DD/YYYY [american] / DD-MM-YYYY [european] / 21 September 2021 / -90 days',
@@ -6047,7 +6047,7 @@ RuleCallContext::$supportedActions[] = Array(
             }
         }
         else
-            derr( 'only supported in API mode' );
+            derr( 'only supported in API mode', null, FALSE);
     },
     'args' => Array( 'logHistory' => Array( 'type' => 'string', 'default' => 'last-15-minutes' ) ),
     'help' => 'returns TRUE if rule name matches the specified timestamp MM/DD/YYYY [american] / DD-MM-YYYY [european] / 21 September 2021 / -90 days',
@@ -6090,7 +6090,7 @@ RuleCallContext::$supportedActions[] = Array(
             }
         }
         else
-            derr( 'only supported in API mode' );
+            derr( 'only supported in API mode', null, FALSE);
     },
     'args' => Array( 'logHistory' => Array( 'type' => 'string', 'default' => 'last-15-minutes' ) ),
     'help' => 'returns TRUE if rule name matches the specified timestamp MM/DD/YYYY [american] / DD-MM-YYYY [european] / 21 September 2021 / -90 days',
@@ -6106,7 +6106,7 @@ RuleCallContext::$supportedActions[] = array(
         $rule = $context->object;
 
         if( !$context->isAPI )
-            derr('you cannot call this action without API mode');
+            derr('you cannot call this action without API mode', null, FALSE);
 
         if( $context->first )
         {
@@ -6115,7 +6115,7 @@ RuleCallContext::$supportedActions[] = array(
                 $text = file_get_contents($context->arguments['fileName']);
 
                 if( $text === FALSE )
-                    derr("cannot open file '{$context->arguments['fileName']}");
+                    derr("cannot open file '{$context->arguments['fileName']}", null, FALSE);
 
                 $lines = explode("\n", $text);
                 foreach( $lines as $line )

--- a/utils/common/actions-service.php
+++ b/utils/common/actions-service.php
@@ -762,7 +762,9 @@ ServiceCallContext::$supportedActions[] = array(
 
         if( $conflictObject->isTmpSrv() && !$object->isTmpSrv() )
         {
-            derr("unsupported situation with a temporary object");
+            mwarning("unsupported situation with a temporary object", null, FALSE);
+            $string = "unsupported situation with a temporary object";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
             return;
         }
 

--- a/utils/develop/panorama_combine_multiple_shared.php
+++ b/utils/develop/panorama_combine_multiple_shared.php
@@ -1,0 +1,142 @@
+<?php
+
+// load PAN-OS-PHP library
+require_once("lib/pan_php_framework.php");
+require_once "utils/lib/UTIL.php";
+
+
+PH::print_stdout();
+PH::print_stdout("*********** START OF SCRIPT ".basename(__FILE__)." ************" );
+PH::print_stdout();
+
+
+$supportedArguments = array();
+//PREDEFINED arguments:
+$supportedArguments['in'] = array('niceName' => 'in', 'shortHelp' => 'in=filename.xml | api. ie: in=api://192.168.1.1 or in=api://0018CAEC3@panorama.company.com', 'argDesc' => '[filename]|[api://IP]|[api://serial@IP]');
+$supportedArguments['out'] = array('niceName' => 'out', 'shortHelp' => 'output file to save config after changes. Only required when input is a file. ie: out=save-config.xml', 'argDesc' => '[filename]');
+$supportedArguments['debugapi'] = array('niceName' => 'DebugAPI', 'shortHelp' => 'prints API calls when they happen');
+$supportedArguments['help'] = array('niceName' => 'help', 'shortHelp' => 'this message');
+$supportedArguments['location'] = array('niceName' => 'Location', 'shortHelp' => 'specify if you want to limit your query to a VSYS/DG. By default location=shared for Panorama, =vsys1 for PANOS. ie: location=any or location=vsys2,vsys1', 'argDesc' => '=sub1[,sub2]');
+
+$supportedArguments['loadpanoramapushedconfig'] = array('niceName' => 'loadPanoramaPushedConfig', 'shortHelp' => 'load Panorama pushed config from the firewall to take in account panorama objects and rules');
+$supportedArguments['apitimeout'] = array('niceName' => 'apiTimeout', 'shortHelp' => 'in case API takes too long time to anwer, increase this value (default=60)');
+
+$supportedArguments['shadow-disableoutputformatting'] = array('niceName' => 'shadow-disableoutputformatting', 'shortHelp' => 'XML output in offline config is not in cleaned PHP DOMDocument structure');
+$supportedArguments['shadow-enablexmlduplicatesdeletion']= array('niceName' => 'shadow-enablexmlduplicatesdeletion', 'shortHelp' => 'if duplicate objects are available, keep only one object of the same name');
+$supportedArguments['shadow-ignoreinvalidaddressobjects']= array('niceName' => 'shadow-ignoreinvalidaddressobjects', 'shortHelp' => 'PAN-OS allow to have invalid address objects available, like object without value or type');
+$supportedArguments['shadow-apikeynohidden'] = array('niceName' => 'shadow-apikeynohidden', 'shortHelp' => 'send API-KEY in clear text via URL. this is needed for all PAN-OS version <9.0 if API mode is used. ');
+$supportedArguments['shadow-apikeynosave']= array('niceName' => 'shadow-apikeynosave', 'shortHelp' => 'do not store API key in .panconfkeystore file');
+$supportedArguments['shadow-displaycurlrequest']= array('niceName' => 'shadow-displaycurlrequest', 'shortHelp' => 'display curl information if running in API mode');
+$supportedArguments['shadow-reducexml']= array('niceName' => 'shadow-reducexml', 'shortHelp' => 'store reduced XML, without newline and remove blank characters in offline mode');
+$supportedArguments['shadow-json']= array('niceName' => 'shadow-json', 'shortHelp' => 'BETA command to display output on stdout not in text but in JSON format');
+
+//YOUR OWN arguments if needed
+$supportedArguments['argument1'] = array('niceName' => 'ARGUMENT1', 'shortHelp' => 'an argument you like to use in your script');
+$supportedArguments['optional_argument2'] = array('niceName' => 'Optional_Argument2', 'shortHelp' => 'an argument you like to define here');
+
+
+$usageMsg = PH::boldText('USAGE: ') . "php " . basename(__FILE__) . " in=api:://[MGMT-IP] argument1 [optional_argument2]";
+
+
+$util = new UTIL("custom", $argv, $argc,__FILE__, $supportedArguments, $usageMsg );
+
+$util->utilInit();
+
+$util->load_config();
+$util->location_filter();
+
+
+/** @var PANConf|PanoramaConf $pan */
+$pan = $util->pan;
+
+
+/** @var VirtualSystem|DeviceGroup $sub */
+$sub = $util->sub;
+
+/** @var string $location */
+$location = $util->location;
+
+/** @var boolean $apiMode */
+$apiMode = $util->apiMode;
+
+/** @var array $args */
+$args = PH::$args;
+
+PH::print_stdout();
+PH::print_stdout( "    **********     **********" );
+PH::print_stdout();
+
+/*********************************
+ * *
+ * *  START WRITING YOUR CODE HERE
+ * *
+ * * List of available variables:
+ *
+ * * $pan : PANConf or PanoramaConf object
+ * * $location : string with location name or undefined if not provided on CLI
+ * * $sub : DeviceGroup or VirtualSystem found after looking from cli 'location' argument
+ * * $apiMode : if config file was downloaded from API directly
+ * * $args : array with all CLI arguments processed by PAN-OS-PHP
+ * *
+ */
+
+PH::print_stdout( "copy shared DG from multiple Panorama config files into a new Panorama config");
+
+//define all Panorama files
+//empty one
+//how to flexible read all possible panorama files?
+
+$file_array = array();
+$file_array[] = "panorama1.xml";
+$file_array[] = "panorama2.xml";
+$file_array[] = "panorama3.xml";
+
+
+
+
+foreach( $file_array as  $key =>  $filename )
+{
+    //read Panorama file
+    //- get XML
+    //- search xpath /config/shared
+    //- based on how many files, create DGx
+    //- add all child from /config/shared to DGx
+    $xmlDoc = new DOMDocument();
+    PH::print_stdout( " - Reading XML file from disk... ".$filename );
+    if( !$xmlDoc->load($filename, XML_PARSE_BIG_LINES) )
+        derr("error while reading xml config file");
+
+    $xpath = "/config/shared";
+    $xpathResult = DH::findXPath( $xpath, $xmlDoc);
+    PH::print_stdout( "   * XPATH: ".$xpath );
+
+    $tmpSTring = $key + 1;
+    $DG = $pan->createDeviceGroup( "DG".(string)$tmpSTring );
+
+    foreach( $xpathResult as $xpath )
+    {
+        foreach( $xpath->childNodes as $node )
+        {
+            if( $node->nodeType != XML_ELEMENT_NODE )
+                continue;
+
+            $tmpNode = $pan->xmlroot->ownerDocument->importNode($node, TRUE);
+            $nodeName = $tmpNode->nodeName;
+
+            #$allowedImport = array("address", "address-group", "service", "service-group", "tag");
+            #if( in_array( $nodeName, $allowedImport) )
+            #{
+                $nodeElement = DH::findFirstElement( $nodeName, $DG->xmlroot );
+                if( $nodeElement !== FALSE )
+                    $DG->xmlroot->removeChild($nodeElement);
+                $DG->xmlroot->appendChild( $tmpNode );
+            #}
+        }
+    }
+}
+
+$util->save_our_work();
+PH::print_stdout();
+PH::print_stdout( "************* END OF SCRIPT ".basename(__FILE__)." ************" );
+PH::print_stdout();
+

--- a/utils/lib/CUSTOMREPORT.php
+++ b/utils/lib/CUSTOMREPORT.php
@@ -13,7 +13,7 @@ class CUSTOMREPORT extends UTIL
         $this->supportedArguments['in'] = Array('niceName' => 'in', 'shortHelp' => 'input file ie: in=config.xml', 'argDesc' => '[filename]');
         $this->supportedArguments['debugapi'] = Array('niceName' => 'DebugAPI', 'shortHelp' => 'prints API calls when they happen');
         $this->supportedArguments['help'] = Array('niceName' => 'help', 'shortHelp' => 'this message');
-        $this->supportedArguments['report-file'] = Array('niceName' => 'report-file', 'shortHelp' => 'file which containers custom report information');
+        $this->supportedArguments['report-file'] = Array('niceName' => 'report-file', 'shortHelp' => 'file which contains custom report information');
         $this->supportedArguments['apitimeout'] = Array('niceName' => 'apiTimeout', 'shortHelp' => 'in case API takes too long time to anwer, increase this value (default=60)');
 
         $this->usageMsg = PH::boldText('USAGE: ')."php ".basename(__FILE__)." in=api://192.168.55.100 location=shared [Actions=display] ['Filter=(subtype eq pppoe)'] ...";

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -2465,7 +2465,7 @@ class MERGER extends UTIL
                     if( $object !== $tmp_service )
                     {
                         PH::print_stdout("    - group '{$object->name()}' DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $tmp_service->owner->owner->name() . "', deleting: " . $object->_PANC_shortName());
-
+                        self::deletedObject($index, $tmp_service, $object);
                         PH::print_stdout("    - replacing '{$object->_PANC_shortName()}' ...");
                         if( $this->action === "merge" )
                         {
@@ -2546,7 +2546,7 @@ class MERGER extends UTIL
                                 else
                                     $tmp_ancestor_DGname = "shared";
                                 $text = "    - group '{$object->name()}' DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $tmp_ancestor_DGname . "', deleting: " . $object->_PANC_shortName();
-                                self::deletedObject($index, $pickedObject, $object);
+                                self::deletedObject($index, $ancestor, $object);
                                 if( $this->action === "merge" )
                                 {
                                     $object->replaceMeGlobally($ancestor);
@@ -3110,6 +3110,7 @@ class MERGER extends UTIL
                                         }
 
                                     $text = "    - object '{$object->name()}' merged with its ancestor, deleting: ".$object->_PANC_shortName();
+                                    self::deletedObject($index, $ancestor, $object);
                                     if( $this->action === "merge" )
                                     {
                                         $object->replaceMeGlobally($ancestor);

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -3504,8 +3504,11 @@ class MERGER extends UTIL
                             //Todo: validate if this is correct; expectation is not same color swaschkut 20230525
                             if( !$obj->sameValue($pickedObject) ) //true if same color, false if different color
                             {
-                                $exit = true;
-                                $exitObject = $obj;
+                                if( $this->dupAlg !== 'samename' )
+                                {
+                                    $exit = true;
+                                    $exitObject = $obj;
+                                }
                             }
                         }
 

--- a/utils/lib/UTIL.php
+++ b/utils/lib/UTIL.php
@@ -299,7 +299,7 @@ class UTIL
         $this->supportedArguments['shadow-nojson']= array('niceName' => 'shadow-nojson', 'shortHelp' => 'BETA command to display output on stdout in text format');
         $this->supportedArguments['shadow-displayxmlnode']= array('niceName' => 'shadow-displayxmlnode', 'shortHelp' => 'command to display XML node in addition to for actions=display');
         $this->supportedArguments['shadow-saseapiqa']= array('niceName' => 'shadow-saseapiqa', 'shortHelp' => 'command to use QA URLs for SASE API');
-
+        $this->supportedArguments['shadow-loadreduce']= array('niceName' => 'shadow-loadreduce', 'shortHelp' => 'during config load do NOT load dynamic-addressgroup information from address objects TAG based part');
     }
 
     public function utilInit()


### PR DESCRIPTION
UTIL:
* type=rule actions=XYZ | improve error handling

BUGFIX:
* type=service actions=move | bugfix to not error out if pre-defined service object service-http/-https must be merged with an existing object of same name
* type=tag-merger | bugfix if dupalgorithm=samename
* type=address actions=move | bugfix for tag object search
* type=rule | different actions - if last object of src/dst/srv/urlcategory is removed, and if not force any is used, rule will be disabled
* type=device actions=display-shadowrule loadpanoramapushedconfig | extend validation as panoramapushedconfig check is not implemented
* type=rule actions=from-remove-from-file/to-remove-from-file | bugfix as wrong from/to zone are removed
* class NAT | bugfix of none correct variable name $connector
* type=service-merger | bugfix for exportcsv=file.html to add also deleted objects where an ancestor at upperlevel is available

GENERAL:
* update to Device App-ID version: 8785-8431