### PR TITLE
publish 2.1.32

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,9 @@ CHANGELOG
 
 2.1.32
 UTIL:
-* type=address | introdruce 'filter=(reflocationtype is.virtualsystem)' / is.only.virtualsystem
+* type=address | introduce 'filter=(reflocationtype is.virtualsystem)' / is.only.virtualsystem
+* type=address | introduce 'filter=(refstore is.rulestore)' / is.only.rulestore
+* type=address | introduce 'filter=(refstore is.addressstore)' / is.only.addressstore
 * type=application | introduce 'filter=(technology eq XYZ)' /  (category eq XYZ)
 * type=application | introduce actions=exporttoexcel:app_name.html
 * different network class | improvement to change address object name and change references - same as merging address objects and change ref

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ BUGFIX:
 GENERAL:
 * class VirtualSystem - ethernet subInterfaces, add address objects references
 * introduce class SecureWebGateway | to reference used interfaces
+* continue working on SCM - Fawkes/Buckbeak - class Container/DeviceCloud/DeviceOnPrem
 
 
 2.1.31  (20250106)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,14 @@
 CHANGELOG
 
-2.1.31
+2.1.32
+UTIL:
+
+BUGFIX:
+
+GENERAL:
+
+
+2.1.31  (20250106)
 UTIL:
 * type=address | introduce new IPv6 'filter=(value ip6.included-in.from.file / ip6.includes-full-or-partial.from.file     - ip6.includes-full.from.file / ip6.match.exact.from.file FILENAME)'
 * type=securityprofile | introdruce actions=url.best-practice-set

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ UTIL:
 * different network class | improvement to change address object name and change references - same as merging address objects and change ref
 
 BUGFIX:
+* bugfix | class AntiSpyware / EDL / VulnerabilityProfile
 
 GENERAL:
 * class VirtualSystem - ethernet subInterfaces, add address objects references

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ UTIL:
 * type=application | introduce actions=exporttoexcel:app_name.html
 * different network class | improvement to change address object name and change references - same as merging address objects and change ref
 * class ReferenceableObject - extend ReferencesStoreValidation | type=address introduce different filter=(refstore is.XYZ
+* type=address-merger | final implementation for apimode if network part is using address objects
 
 BUGFIX:
 * bugfix | class AntiSpyware / EDL / VulnerabilityProfile

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ BUGFIX:
 
 GENERAL:
 * class VirtualSystem - ethernet subInterfaces, add address objects references
+* introduce class SecureWebGateway | to reference used interfaces
 
 
 2.1.31  (20250106)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ UTIL:
 * introduction for type=ike-profile/ike-gateway/ipsec-profile/ipsec-tunnel/gre-tunnel
 * type=address | introduce 'actions=display-xpath-usage'
 * type=address-merger | skip if address object reference is from Class type of not implemented for merging
+* class GreTunnel | add address object reference - benefit for type=address-merger to see all address object references
 
 BUGFIX:
 * type=securityprofile securityprofiletype=spyware actions=best-practice-set | bugfix

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTIL:
 * type=address | introdruce 'filter=(reflocationtype is.virtualsystem)' / is.only.virtualsystem
 * type=application | introduce 'filter=(technology eq XYZ)' /  (category eq XYZ)
+* type=application | introduce actions=exporttoexcel:app_name.html
 
 BUGFIX:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ CHANGELOG
 2.1.32
 UTIL:
 * type=address | introdruce 'filter=(reflocationtype is.virtualsystem)' / is.only.virtualsystem
+* type=application | introduce 'filter=(technology eq XYZ)' /  (category eq XYZ)
 
 BUGFIX:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTIL:
 * type=address | introdruce 'filter=(reflocationtype is.virtualsystem)' / is.only.virtualsystem
 * type=application | introduce 'filter=(technology eq XYZ)' /  (category eq XYZ)
 * type=application | introduce actions=exporttoexcel:app_name.html
+* different network class | improvement to change address object name and change references - same as merging address objects and change ref
 
 BUGFIX:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTIL:
 BUGFIX:
 
 GENERAL:
+* class VirtualSystem - ethernet subInterfaces, add address objects references
 
 
 2.1.31  (20250106)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTIL:
 * type=application | introduce 'filter=(technology eq XYZ)' /  (category eq XYZ)
 * type=application | introduce actions=exporttoexcel:app_name.html
 * different network class | improvement to change address object name and change references - same as merging address objects and change ref
+* class ReferenceableObject - extend ReferencesStoreValidation | type=address introduce different filter=(refstore is.XYZ
 
 BUGFIX:
 * bugfix | class AntiSpyware / EDL / VulnerabilityProfile

--- a/lib/device-and-system-classes/Container.php
+++ b/lib/device-and-system-classes/Container.php
@@ -63,6 +63,12 @@ class Container
     /** @var SecurityProfileStore */
     public $SaasSecurityProfileStore = null;
 
+    /** @var ThreatPolicyStore */
+    public $ThreatPolicyStore = null;
+
+    /** @var DNSPolicyStore */
+    public $DNSPolicyStore = null;
+
     /** @var SecurityProfileStore */
     public $VulnerabilityProfileStore = null;
 
@@ -122,6 +128,8 @@ class Container
     /** @var ScheduleStore */
     public $scheduleStore = null;
 
+    /** @var EDLStore */
+    public $EDLStore = null;
 
     //Todo: add secprofiles and secprofgroups| 20200312 swaschkut
   /*  public static $templateContainerxml = '<entry name="**Need a Name**"><address></address><post-rulebase><security><rules></rules></security><nat><rules></rules></nat></post-rulebase>
@@ -257,6 +265,12 @@ class Container
         $this->SaasSecurityProfileStore = new SecurityProfileStore($this, "SaasSecurityProfile");
         $this->SaasSecurityProfileStore->name = 'SaasSecurity';
 
+        $this->ThreatPolicyStore = new ThreatPolicyStore($this, "ThreatPolicy");
+        $this->ThreatPolicyStore->name = 'ThreatPolicy';
+
+        $this->DNSPolicyStore = new DNSPolicyStore($this, "DNSPolicy");
+        $this->DNSPolicyStore->name = 'DNSPolicy';
+
         $this->VulnerabilityProfileStore = new SecurityProfileStore($this, "VulnerabilityProfile");
         $this->VulnerabilityProfileStore->name = 'Vulnerability';
 
@@ -313,6 +327,9 @@ class Container
 
         $this->scheduleStore = new ScheduleStore($this);
         $this->scheduleStore->setName('scheduleStore');
+
+        $this->EDLStore = new EDLStore($this);
+        $this->EDLStore->setName('EDLStore');
 
         $this->securityRules = new RuleStore($this, 'SecurityRule', TRUE);
         $this->natRules = new RuleStore($this, 'NatRule', TRUE);
@@ -646,6 +663,14 @@ class Container
             $this->scheduleStore->load_from_domxml($tmp);
         // End of address groups extraction
 
+        //
+        // Extract EDL objects
+        //
+        $tmp = DH::findFirstElement('external-list', $xml);
+        if( $tmp !== FALSE )
+            $this->EDLStore->load_from_domxml($tmp);
+        // End of EDL extraction
+        
         //
         // Extracting policies
         //

--- a/lib/device-and-system-classes/DeviceCloud.php
+++ b/lib/device-and-system-classes/DeviceCloud.php
@@ -56,6 +56,12 @@ class DeviceCloud
     /** @var SecurityProfileStore */
     public $SaasSecurityProfileStore = null;
 
+    /** @var ThreatPolicyStore */
+    public $ThreatPolicyStore = null;
+
+    /** @var DNSPolicyStore */
+    public $DNSPolicyStore = null;
+
     /** @var SecurityProfileStore */
     public $VulnerabilityProfileStore = null;
 
@@ -115,6 +121,8 @@ class DeviceCloud
     /** @var ScheduleStore */
     public $scheduleStore = null;
 
+    /** @var EDLStore */
+    public $EDLStore = null;
 
 /*
     public static $templateCloudxml = '<entry name="**Need a Name**"><address></address>
@@ -250,6 +258,12 @@ class DeviceCloud
         $this->SaasSecurityProfileStore = new SecurityProfileStore($this, "SaasSecurityProfile");
         $this->SaasSecurityProfileStore->name = 'SaasSecurity';
 
+        $this->ThreatPolicyStore = new ThreatPolicyStore($this, "ThreatPolicy");
+        $this->ThreatPolicyStore->name = 'ThreatPolicy';
+
+        $this->DNSPolicyStore = new DNSPolicyStore($this, "DNSPolicy");
+        $this->DNSPolicyStore->name = 'DNSPolicy';
+
         $this->VulnerabilityProfileStore = new SecurityProfileStore($this, "VulnerabilityProfile");
         $this->VulnerabilityProfileStore->name = 'Vulnerability';
 
@@ -307,6 +321,8 @@ class DeviceCloud
         $this->scheduleStore = new ScheduleStore($this);
         $this->scheduleStore->setName('scheduleStore');
 
+        $this->EDLStore = new EDLStore($this);
+        $this->EDLStore->setName('EDLStore');
 
         $this->securityRules = new RuleStore($this, 'SecurityRule');
         $this->securityRules->name = 'Security';
@@ -733,6 +749,13 @@ class DeviceCloud
                 $this->scheduleStore->load_from_domxml($tmp);
             // End of address groups extraction
 
+            //
+            // Extract EDL objects
+            //
+            $tmp = DH::findFirstElement('external-list', $xml);
+            if( $tmp !== FALSE )
+                $this->EDLStore->load_from_domxml($tmp);
+            // End of EDL extraction
         }
 
 

--- a/lib/device-and-system-classes/DeviceOnPrem.php
+++ b/lib/device-and-system-classes/DeviceOnPrem.php
@@ -115,6 +115,8 @@ class DeviceOnPrem
     /** @var ScheduleStore */
     public $scheduleStore = null;
 
+    /** @var EDLStore */
+    public $EDLStore = null;
 
 /*
     public static $templateCloudxml = '<entry name="**Need a Name**"><address></address>
@@ -311,6 +313,8 @@ class DeviceOnPrem
         $this->scheduleStore = new ScheduleStore($this);
         $this->scheduleStore->setName('scheduleStore');
 
+        $this->EDLStore = new EDLStore($this);
+        $this->EDLStore->setName('EDLStore');
 
         $this->securityRules = new RuleStore($this, 'SecurityRule');
         $this->securityRules->name = 'Security';
@@ -736,6 +740,13 @@ class DeviceOnPrem
                 $this->scheduleStore->load_from_domxml($tmp);
             // End of address groups extraction
 
+            //
+            // Extract EDL objects
+            //
+            $tmp = DH::findFirstElement('external-list', $xml);
+            if( $tmp !== FALSE )
+                $this->EDLStore->load_from_domxml($tmp);
+            // End of EDL extraction
         }
 
 

--- a/lib/device-and-system-classes/VirtualSystem.php
+++ b/lib/device-and-system-classes/VirtualSystem.php
@@ -778,6 +778,16 @@ class VirtualSystem
                     $interfacesv4 = $interface->getLayer3IPv4Addresses();
                     $interfacesv6 = $interface->getLayer3IPv6Addresses();
                     $interfaces = array_merge($interfacesv4, $interfacesv6);
+
+                    if( !empty($interface->subInterfaces()) )
+                    {
+                        foreach( $interface->subInterfaces() as $subinterface )
+                        {
+                            $interfacesv4 = $subinterface->getLayer3IPv4Addresses();
+                            $interfacesv6 = $subinterface->getLayer3IPv6Addresses();
+                            $interfaces = array_merge($interfacesv4, $interfacesv6);
+                        }
+                    }
                 }
                 elseif( $interface->isVlanType() || $interface->isLoopbackType() || $interface->isTunnelType() )
                 {
@@ -785,6 +795,8 @@ class VirtualSystem
                     $interfacesv6 = $interface->getIPv6Addresses();
                     $interfaces = array_merge($interfacesv4, $interfacesv6);
                 }
+                //elseif( $interface->isAggregateType() )
+                //{}
 
                 else
                     $interfaces = array();

--- a/lib/device-and-system-classes/VirtualSystem.php
+++ b/lib/device-and-system-classes/VirtualSystem.php
@@ -785,7 +785,14 @@ class VirtualSystem
                         {
                             $interfacesv4 = $subinterface->getLayer3IPv4Addresses();
                             $interfacesv6 = $subinterface->getLayer3IPv6Addresses();
-                            $interfaces = array_merge($interfacesv4, $interfacesv6);
+                            $sub_interfaces = array_merge($interfacesv4, $interfacesv6);
+
+                            foreach( $sub_interfaces as $layer3IPAddress )
+                            {
+                                $findobject = $this->addressStore->find($layer3IPAddress);
+                                if( is_object($findobject) )
+                                    $findobject->addReference($subinterface);
+                            }
                         }
                     }
                 }

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -230,7 +230,7 @@ class PH
 
     private static $library_version_major = 2;
     private static $library_version_sub = 1;
-    private static $library_version_bugfix = 31;
+    private static $library_version_bugfix = 32;
 
     //BASIC AUTH PAN-OS 7.1
     public static $softwareupdate_key = "658d787f293e631196dac9fb29490f1cc1bb3827";

--- a/lib/misc-classes/filters/filters-Address.php
+++ b/lib/misc-classes/filters/filters-Address.php
@@ -1054,20 +1054,69 @@ RQuery::$defaultFilters['address']['refstore']['operators']['is.rulestore'] = ar
         'input' => 'input/panorama-8.0.xml'
     )
 );
-RQuery::$defaultFilters['address']['refstore']['operators']['is.addressstore'] = array(
+RQuery::$defaultFilters['address']['refstore']['operators']['is.only.rulestore'] = array(
     'Function' => function (AddressRQueryContext $context) {
         #$value = $context->value;
         #$value = strtolower($value);
+        $value = "rulestore";
+
+        $context->object->ReferencesStoreValidation($value);
+        $refstore_array = $context->object->getReferencesStore();
+
+        $return = FALSE;
+        foreach( $refstore_array as $refstore => $value )
+        {
+            if( $refstore == $value )
+                $return = TRUE;
+            else
+                return FALSE;
+        }
+
+        return $return;
+
+    },
+    'arg' => false,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['address']['refstore']['operators']['is.addressstore'] = array(
+    'Function' => function (AddressRQueryContext $context) {
         $value = "addressstore";
 
         $context->object->ReferencesStoreValidation($value);
-
         $refstore = $context->object->getReferencesStore();
 
         if( array_key_exists($value, $refstore) )
             return TRUE;
 
         return FALSE;
+
+    },
+    'arg' => false,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['address']['refstore']['operators']['is.only.addressstore'] = array(
+    'Function' => function (AddressRQueryContext $context) {
+        $value = "addressstore";
+
+        $context->object->ReferencesStoreValidation($value);
+        $refstore_array = $context->object->getReferencesStore();
+
+        $return = FALSE;
+        foreach( $refstore_array as $refstore => $value )
+        {
+            if( $refstore == $value )
+                $return = TRUE;
+            else
+                return FALSE;
+        }
+
+        return $return;
 
     },
     'arg' => false,

--- a/lib/misc-classes/filters/filters-Address.php
+++ b/lib/misc-classes/filters/filters-Address.php
@@ -1032,6 +1032,160 @@ RQuery::$defaultFilters['address']['refstore']['operators']['is'] = array(
         'input' => 'input/panorama-8.0.xml'
     )
 );
+RQuery::$defaultFilters['address']['refstore']['operators']['is.rulestore'] = array(
+    'Function' => function (AddressRQueryContext $context) {
+        #$value = $context->value;
+        #$value = strtolower($value);
+        $value = "rulestore";
+
+        $context->object->ReferencesStoreValidation($value);
+
+        $refstore = $context->object->getReferencesStore();
+
+        if( array_key_exists($value, $refstore) )
+            return TRUE;
+
+        return FALSE;
+
+    },
+    'arg' => false,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['address']['refstore']['operators']['is.addressstore'] = array(
+    'Function' => function (AddressRQueryContext $context) {
+        #$value = $context->value;
+        #$value = strtolower($value);
+        $value = "addressstore";
+
+        $context->object->ReferencesStoreValidation($value);
+
+        $refstore = $context->object->getReferencesStore();
+
+        if( array_key_exists($value, $refstore) )
+            return TRUE;
+
+        return FALSE;
+
+    },
+    'arg' => false,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['address']['refstore']['operators']['is.servicestore'] = array(
+    'Function' => function (AddressRQueryContext $context) {
+        #$value = $context->value;
+        #$value = strtolower($value);
+        $value = "servicestore";
+
+        $context->object->ReferencesStoreValidation($value);
+
+        $refstore = $context->object->getReferencesStore();
+
+        if( array_key_exists($value, $refstore) )
+            return TRUE;
+
+        return FALSE;
+
+    },
+    'arg' => false,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['address']['refstore']['operators']['is.logicalrouterstore'] = array(
+    'Function' => function (AddressRQueryContext $context) {
+        #$value = $context->value;
+        #$value = strtolower($value);
+        $value = "logicalrouterstore";
+
+        $context->object->ReferencesStoreValidation($value);
+
+        $refstore = $context->object->getReferencesStore();
+
+        if( array_key_exists($value, $refstore) )
+            return TRUE;
+
+        return FALSE;
+
+    },
+    'arg' => false,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['address']['refstore']['operators']['is.virtualrouterstore'] = array(
+    'Function' => function (AddressRQueryContext $context) {
+        #$value = $context->value;
+        #$value = strtolower($value);
+        $value = "virtualrouterstore";
+
+        $context->object->ReferencesStoreValidation($value);
+
+        $refstore = $context->object->getReferencesStore();
+
+        if( array_key_exists($value, $refstore) )
+            return TRUE;
+
+        return FALSE;
+
+    },
+    'arg' => false,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['address']['refstore']['operators']['is.tunnelifstore'] = array(
+    'Function' => function (AddressRQueryContext $context) {
+        #$value = $context->value;
+        #$value = strtolower($value);
+        $value = "tunnelifstore";
+
+        $context->object->ReferencesStoreValidation($value);
+
+        $refstore = $context->object->getReferencesStore();
+
+        if( array_key_exists($value, $refstore) )
+            return TRUE;
+
+        return FALSE;
+
+    },
+    'arg' => false,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['address']['refstore']['operators']['is.gpgatewaystore'] = array(
+    'Function' => function (AddressRQueryContext $context) {
+        #$value = $context->value;
+        #$value = strtolower($value);
+        $value = "gpgatewaystore";
+
+        $context->object->ReferencesStoreValidation($value);
+
+        $refstore = $context->object->getReferencesStore();
+
+        if( array_key_exists($value, $refstore) )
+            return TRUE;
+
+        return FALSE;
+
+    },
+    'arg' => false,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
 RQuery::$defaultFilters['address']['reftype']['operators']['is'] = array(
     'Function' => function (AddressRQueryContext $context) {
         $value = $context->value;

--- a/lib/misc-classes/filters/filters-Address.php
+++ b/lib/misc-classes/filters/filters-Address.php
@@ -1186,6 +1186,28 @@ RQuery::$defaultFilters['address']['refstore']['operators']['is.gpgatewaystore']
         'input' => 'input/panorama-8.0.xml'
     )
 );
+RQuery::$defaultFilters['address']['refstore']['operators']['is.ikegatewaystore'] = array(
+    'Function' => function (AddressRQueryContext $context) {
+        #$value = $context->value;
+        #$value = strtolower($value);
+        $value = "ikegatewaystore";
+
+        $context->object->ReferencesStoreValidation($value);
+
+        $refstore = $context->object->getReferencesStore();
+
+        if( array_key_exists($value, $refstore) )
+            return TRUE;
+
+        return FALSE;
+
+    },
+    'arg' => false,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
 RQuery::$defaultFilters['address']['reftype']['operators']['is'] = array(
     'Function' => function (AddressRQueryContext $context) {
         $value = $context->value;

--- a/lib/misc-classes/filters/filters-Application.php
+++ b/lib/misc-classes/filters/filters-Application.php
@@ -93,6 +93,38 @@ RQuery::$defaultFilters['application']['characteristic']['operators']['has'] = a
     )
 );
 
+RQuery::$defaultFilters['application']['technology']['operators']['eq'] = array(
+    'Function' => function (ApplicationRQueryContext $context) {
+        $app = $context->object;
+
+        if( $app->isContainer() )
+            return null;
+
+        if( $app->technology === strtolower($context->value) )
+            return TRUE;
+
+        return FALSE;
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% evasive) ',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+
+RQuery::$defaultFilters['application']['category']['operators']['eq'] = array(
+    'Function' => function (ApplicationRQueryContext $context) {
+        if( $context->object->category == $context->value )
+            return TRUE;
+
+        return FALSE;
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
 
 RQuery::$defaultFilters['application']['object']['operators']['is.predefined'] = array(
     'Function' => function (ApplicationRQueryContext $context) {

--- a/lib/misc-classes/trait/ReferenceableObject.php
+++ b/lib/misc-classes/trait/ReferenceableObject.php
@@ -390,7 +390,11 @@ trait ReferenceableObject
             if( isset($cur->owner->owner) && $cur->owner->owner !== null )
             {
                 $class = get_class($cur->owner->owner);
-                if( $class == "DeviceGroup" || $class == "VirtualSystem" || $class == "PanoramaConf" )
+                if( $class == "PanoramaConf" || $class == "PANConf"
+                    || $class == "DeviceGroup" || $class == "VirtualSystem"
+                    || $class == "BuckbeakConf" || $class == "FawkesConf"
+                    || $class == "Container" || $class == "DeviceCloud" || $class == "DeviceOnPrem" || $class == "Snippet"
+                )
                     $class = get_class($cur->owner);
                 $class = strtolower($class);
                 $store_array[$class] = $class;
@@ -409,6 +413,17 @@ trait ReferenceableObject
         $store_array['servicestore'] = FALSE;
         $store_array['rulestore'] = FALSE;
         $store_array['securityprofilegroupstore'] = FALSE;
+
+        $store_array['logicalrouterstore'] = FALSE;
+        $store_array['virtualrouterstore'] = FALSE;
+        $store_array['ethernetifstore'] = FALSE;
+        $store_array['tunnelifstore'] = FALSE;
+        $store_array['gpgatewaystore'] = FALSE;
+        $store_array['gpportalstore'] = FALSE;
+        $store_array['ikegatewaystore'] = FALSE;
+        $store_array['gretunnelstore'] = FALSE;
+        $store_array['loopbackifstore'] = FALSE;
+        $store_array['vlanifstore'] = FALSE;
 
 
         if( !array_key_exists($value, $store_array) )

--- a/lib/misc-classes/trait/ReferenceableObject.php
+++ b/lib/misc-classes/trait/ReferenceableObject.php
@@ -507,6 +507,22 @@ trait ReferenceableObject
         return $ret;
     }
 
+    /**
+     * @param string $className
+     * @return array
+     */
+    public function & findReferencesWithOwnerClass($className)
+    {
+        $ret = array();
+
+        foreach( $this->refrules as $reference )
+        {
+            if( get_class($reference->owner) == $className )
+                $ret[] = $reference;
+        }
+
+        return $ret;
+    }
 
     public function name()
     {

--- a/lib/misc-classes/trait/ReferenceableObject.php
+++ b/lib/misc-classes/trait/ReferenceableObject.php
@@ -390,7 +390,7 @@ trait ReferenceableObject
             if( isset($cur->owner->owner) && $cur->owner->owner !== null )
             {
                 $class = get_class($cur->owner->owner);
-                if( $class == "DeviceGroup" )
+                if( $class == "DeviceGroup" || $class == "VirtualSystem" || $class == "PanoramaConf" )
                     $class = get_class($cur->owner);
                 $class = strtolower($class);
                 $store_array[$class] = $class;

--- a/lib/network-classes/EthernetInterface.php
+++ b/lib/network-classes/EthernetInterface.php
@@ -868,38 +868,8 @@ class EthernetInterface
 
     public function replaceReferencedObject($old, $new)
     {
-        /*
-        if( $old === $new )
-            return FALSE;
-
-        $pos = array_search($old, $this->o, TRUE);
-
-        if( $pos !== FALSE )
-        {
-            while( $pos !== FALSE )
-            {
-                unset($this->o[$pos]);
-                $pos = array_search($old, $this->o, TRUE);
-            }
-
-            if( $new !== null && !$this->has($new->name()) )
-            {
-                $this->o[] = $new;
-                $new->addReference($this);
-            }
-            $old->removeReference($this);
-
-            if( $new === null || $new->name() != $old->name() )
-                $this->rewriteXML();
-
-            return TRUE;
-        }
-        #elseif( !$this->isDynamic() )
-        #    mwarning("object is not part of this group: " . $old->toString());
-        */
-
-
-        return FALSE;
+        $this->referencedObjectRenamed($new, $old->name());
+        return true;
     }
 
     public function API_replaceReferencedObject($old, $new)

--- a/lib/network-classes/EthernetInterface.php
+++ b/lib/network-classes/EthernetInterface.php
@@ -188,7 +188,6 @@ class EthernetInterface
                                 $shared_object = $panorama_object->addressStore->find($tmpIP);
                                 if( $shared_object != null )
                                 {
-                                    print "add reference: ".$shared_object->name()."\n";
                                     $shared_object->addReference($this);
                                     $this->l3ipv6Addresses[] = $shared_object->value();
                                 }

--- a/lib/network-classes/EthernetInterface.php
+++ b/lib/network-classes/EthernetInterface.php
@@ -480,7 +480,7 @@ class EthernetInterface
         if( is_object($ip) )
         {
             $ip = $ip->name();
-            derr( "adding address object to Interface not implemented yet", null, False );
+            derr( "adding address object to Interface not implemented yet", null, false );
         }
 
         $ip = $this->findorCreateAddressObject( $ip );
@@ -833,6 +833,7 @@ class EthernetInterface
         {
             if( get_class( $h ) == "Address" )
             {
+                //to get XMLfile correct why not act like replacing an object by name?
                 $this->addIPv4Address( $h );
 
                 $this->removeIPv4Address( $old );

--- a/lib/network-classes/GPGateway.php
+++ b/lib/network-classes/GPGateway.php
@@ -349,6 +349,93 @@ class GPGateway
         return $this->localAddress_ipv6;
     }
 
+    public function referencedObjectRenamed($h, $old)
+    {
+        if( is_object($h) )
+        {
+            if( get_class( $h ) == "Address" )
+            {
+                //Text replace
+                $qualifiedNodeName = '//*[text()="'.$old.'"]';
+                $xpathResult = DH::findXPath( $qualifiedNodeName, $this->xmlroot);
+                foreach( $xpathResult as $node )
+                    $node->textContent = $h->name();
+
+
+                //attribute replace
+                $nameattribute = $old;
+                $qualifiedNodeName = "entry";
+                $nodeList = $this->xmlroot->getElementsByTagName($qualifiedNodeName);
+                $nodeArray = iterator_to_array($nodeList);
+                foreach( $nodeArray as $item )
+                {
+                    if ($nameattribute !== null)
+                    {
+                        $XMLnameAttribute = DH::findAttribute("name", $item);
+                        if ($XMLnameAttribute === FALSE)
+                            continue;
+
+                        if ($XMLnameAttribute !== $nameattribute)
+                            continue;
+                    }
+                    $item->setAttribute('name', $h->name());
+                }
+            }
+
+            return;
+        }
+
+        mwarning("object is not part of this Tunnel Interface : {$h->toString()}");
+    }
+
+    public function replaceReferencedObject($old, $new)
+    {
+        /*
+        if( $old === $new )
+            return FALSE;
+
+        $pos = array_search($old, $this->o, TRUE);
+
+        if( $pos !== FALSE )
+        {
+            while( $pos !== FALSE )
+            {
+                unset($this->o[$pos]);
+                $pos = array_search($old, $this->o, TRUE);
+            }
+
+            if( $new !== null && !$this->has($new->name()) )
+            {
+                $this->o[] = $new;
+                $new->addReference($this);
+            }
+            $old->removeReference($this);
+
+            if( $new === null || $new->name() != $old->name() )
+                $this->rewriteXML();
+
+            return TRUE;
+        }
+        #elseif( !$this->isDynamic() )
+        #    mwarning("object is not part of this group: " . $old->toString());
+        */
+
+
+        return FALSE;
+    }
+
+    public function API_replaceReferencedObject($old, $new)
+    {
+        $ret = $this->replaceReferencedObject($old, $new);
+
+        if( $ret )
+        {
+            $this->API_sync();
+        }
+
+        return $ret;
+    }
+
     public function &getXPath()
     {
         if( $this->isTmp() )

--- a/lib/network-classes/GPGateway.php
+++ b/lib/network-classes/GPGateway.php
@@ -390,38 +390,8 @@ class GPGateway
 
     public function replaceReferencedObject($old, $new)
     {
-        /*
-        if( $old === $new )
-            return FALSE;
-
-        $pos = array_search($old, $this->o, TRUE);
-
-        if( $pos !== FALSE )
-        {
-            while( $pos !== FALSE )
-            {
-                unset($this->o[$pos]);
-                $pos = array_search($old, $this->o, TRUE);
-            }
-
-            if( $new !== null && !$this->has($new->name()) )
-            {
-                $this->o[] = $new;
-                $new->addReference($this);
-            }
-            $old->removeReference($this);
-
-            if( $new === null || $new->name() != $old->name() )
-                $this->rewriteXML();
-
-            return TRUE;
-        }
-        #elseif( !$this->isDynamic() )
-        #    mwarning("object is not part of this group: " . $old->toString());
-        */
-
-
-        return FALSE;
+        $this->referencedObjectRenamed($new, $old->name());
+        return true;
     }
 
     public function API_replaceReferencedObject($old, $new)

--- a/lib/network-classes/GPPortal.php
+++ b/lib/network-classes/GPPortal.php
@@ -253,38 +253,8 @@ class GPPortal
 
     public function replaceReferencedObject($old, $new)
     {
-        /*
-        if( $old === $new )
-            return FALSE;
-
-        $pos = array_search($old, $this->o, TRUE);
-
-        if( $pos !== FALSE )
-        {
-            while( $pos !== FALSE )
-            {
-                unset($this->o[$pos]);
-                $pos = array_search($old, $this->o, TRUE);
-            }
-
-            if( $new !== null && !$this->has($new->name()) )
-            {
-                $this->o[] = $new;
-                $new->addReference($this);
-            }
-            $old->removeReference($this);
-
-            if( $new === null || $new->name() != $old->name() )
-                $this->rewriteXML();
-
-            return TRUE;
-        }
-        #elseif( !$this->isDynamic() )
-        #    mwarning("object is not part of this group: " . $old->toString());
-        */
-
-
-        return FALSE;
+        $this->referencedObjectRenamed($new, $old->name());
+        return true;
     }
 
     public function API_replaceReferencedObject($old, $new)

--- a/lib/network-classes/GPPortal.php
+++ b/lib/network-classes/GPPortal.php
@@ -212,6 +212,93 @@ class GPPortal
         return $this->localAddress_ipv6;
     }
 
+    public function referencedObjectRenamed($h, $old)
+    {
+        if( is_object($h) )
+        {
+            if( get_class( $h ) == "Address" )
+            {
+                //Text replace
+                $qualifiedNodeName = '//*[text()="'.$old.'"]';
+                $xpathResult = DH::findXPath( $qualifiedNodeName, $this->xmlroot);
+                foreach( $xpathResult as $node )
+                    $node->textContent = $h->name();
+
+
+                //attribute replace
+                $nameattribute = $old;
+                $qualifiedNodeName = "entry";
+                $nodeList = $this->xmlroot->getElementsByTagName($qualifiedNodeName);
+                $nodeArray = iterator_to_array($nodeList);
+                foreach( $nodeArray as $item )
+                {
+                    if ($nameattribute !== null)
+                    {
+                        $XMLnameAttribute = DH::findAttribute("name", $item);
+                        if ($XMLnameAttribute === FALSE)
+                            continue;
+
+                        if ($XMLnameAttribute !== $nameattribute)
+                            continue;
+                    }
+                    $item->setAttribute('name', $h->name());
+                }
+            }
+
+            return;
+        }
+
+        mwarning("object is not part of this Tunnel Interface : {$h->toString()}");
+    }
+
+    public function replaceReferencedObject($old, $new)
+    {
+        /*
+        if( $old === $new )
+            return FALSE;
+
+        $pos = array_search($old, $this->o, TRUE);
+
+        if( $pos !== FALSE )
+        {
+            while( $pos !== FALSE )
+            {
+                unset($this->o[$pos]);
+                $pos = array_search($old, $this->o, TRUE);
+            }
+
+            if( $new !== null && !$this->has($new->name()) )
+            {
+                $this->o[] = $new;
+                $new->addReference($this);
+            }
+            $old->removeReference($this);
+
+            if( $new === null || $new->name() != $old->name() )
+                $this->rewriteXML();
+
+            return TRUE;
+        }
+        #elseif( !$this->isDynamic() )
+        #    mwarning("object is not part of this group: " . $old->toString());
+        */
+
+
+        return FALSE;
+    }
+
+    public function API_replaceReferencedObject($old, $new)
+    {
+        $ret = $this->replaceReferencedObject($old, $new);
+
+        if( $ret )
+        {
+            $this->API_sync();
+        }
+
+        return $ret;
+    }
+
     public function &getXPath()
     {
         if( $this->isTmp() )

--- a/lib/network-classes/GreTunnel.php
+++ b/lib/network-classes/GreTunnel.php
@@ -98,11 +98,31 @@ class GreTunnel
             if( $node->nodeName == 'local-address' )
             {
                 $tmp = DH::findFirstElement('interface', $node);
+                if( $tmp !== FALSE )
+                {
+                    $tmpInterface = $this->owner->owner->network->findInterface( $tmp->textContent );
+                    $tmpInterface->addReference( $this->localInterface );
 
-                $tmpInterface = $this->owner->owner->network->findInterface( $tmp->textContent );
-                $tmpInterface->addReference( $this->localInterface );
+                    $this->localInterface->addInterface( $tmpInterface );
+                    PH::print_stdout("add reference: ".$tmp->textContent);
+                }
 
-                $this->localInterface->addInterface( $tmpInterface );
+                $tmp = DH::findFirstElement('ip', $node);
+                if( $tmp !== FALSE )
+                {
+                    $this->localIP = $tmp->textContent;
+
+                    $tmp_interfaces = $this->localInterface->interfaces();
+
+                    /** @var EthernetInterface $tmp_usedInterface */
+                    $tmp_usedInterface = $tmp_interfaces[0];
+
+                    /** @var VirtualSystem $tmp_vsys */
+                    $tmp_vsys = $tmp_usedInterface->importedByVSYS;
+
+                    $tmp_address = $tmp_vsys->addressStore->find($tmp->textContent);
+                    $tmp_address->addReference( $this );
+                }
             }
 
             if( $node->nodeName == 'tunnel-interface' )

--- a/lib/network-classes/GreTunnel.php
+++ b/lib/network-classes/GreTunnel.php
@@ -104,7 +104,6 @@ class GreTunnel
                     $tmpInterface->addReference( $this->localInterface );
 
                     $this->localInterface->addInterface( $tmpInterface );
-                    PH::print_stdout("add reference: ".$tmp->textContent);
                 }
 
                 $tmp = DH::findFirstElement('ip', $node);

--- a/lib/network-classes/GreTunnel.php
+++ b/lib/network-classes/GreTunnel.php
@@ -284,6 +284,24 @@ class GreTunnel
         return TRUE;
     }
 
+    public function replaceReferencedObject($old, $new)
+    {
+        $this->referencedObjectRenamed($new, $old->name());
+        return true;
+    }
+
+    public function API_replaceReferencedObject($old, $new)
+    {
+        $ret = $this->replaceReferencedObject($old, $new);
+
+        if( $ret )
+        {
+            $this->API_sync();
+        }
+
+        return $ret;
+    }
+
     static public $templatexml = '<entry name="**temporarynamechangeme**">
               <local-address></local-address>
               <peer-address></peer-address>

--- a/lib/network-classes/GreTunnelStore.php
+++ b/lib/network-classes/GreTunnelStore.php
@@ -20,6 +20,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+//todo: GRE and IPsectunnel are insame namespace!!!
+
 /**
  * Class GreTunnelStore
  * @property $o GreTunnel[]

--- a/lib/network-classes/IKEGateway.php
+++ b/lib/network-classes/IKEGateway.php
@@ -538,38 +538,8 @@ class IKEGateway
 
     public function replaceReferencedObject($old, $new)
     {
-        /*
-        if( $old === $new )
-            return FALSE;
-
-        $pos = array_search($old, $this->o, TRUE);
-
-        if( $pos !== FALSE )
-        {
-            while( $pos !== FALSE )
-            {
-                unset($this->o[$pos]);
-                $pos = array_search($old, $this->o, TRUE);
-            }
-
-            if( $new !== null && !$this->has($new->name()) )
-            {
-                $this->o[] = $new;
-                $new->addReference($this);
-            }
-            $old->removeReference($this);
-
-            if( $new === null || $new->name() != $old->name() )
-                $this->rewriteXML();
-
-            return TRUE;
-        }
-        #elseif( !$this->isDynamic() )
-        #    mwarning("object is not part of this group: " . $old->toString());
-        */
-
-
-        return FALSE;
+        $this->referencedObjectRenamed($new, $old->name());
+        return true;
     }
 
     public function API_replaceReferencedObject($old, $new)

--- a/lib/network-classes/IPsecTunnel.php
+++ b/lib/network-classes/IPsecTunnel.php
@@ -554,19 +554,45 @@ class IPsecTunnel
         return TRUE;
     }
 
-    public function referencedObjectRenamed($h)
+    public function referencedObjectRenamed($h, $old)
     {
-        if( $this->interface !== $h->name() )
+        if( is_object($h) )
         {
-            //why set it again????
-            $this->interface = $h->name();
+            if( get_class( $h ) == "Address" )
+            {
+                //Text replace
+                $qualifiedNodeName = '//*[text()="'.$old.'"]';
+                $xpathResult = DH::findXPath( $qualifiedNodeName, $this->xmlroot);
+                foreach( $xpathResult as $node )
+                    $node->textContent = $h->name();
 
-            $this->rewriteInterface_XML();
+
+                //attribute replace
+                $nameattribute = $old;
+                $qualifiedNodeName = "entry";
+                $nodeList = $this->xmlroot->getElementsByTagName($qualifiedNodeName);
+                $nodeArray = iterator_to_array($nodeList);
+
+                $templateEntryArray = array();
+                foreach( $nodeArray as $item )
+                {
+                    if ($nameattribute !== null)
+                    {
+                        $XMLnameAttribute = DH::findAttribute("name", $item);
+                        if ($XMLnameAttribute === FALSE)
+                            continue;
+
+                        if ($XMLnameAttribute !== $nameattribute)
+                            continue;
+                    }
+                    $item->setAttribute('name', $h->name());
+                }
+            }
 
             return;
         }
 
-        mwarning("object is not part of this object : {$h->toString()}");
+        mwarning("object is not part of this Tunnel Interface : {$h->toString()}");
     }
 
     public function rewriteInterface_XML()

--- a/lib/network-classes/InterfaceContainer.php
+++ b/lib/network-classes/InterfaceContainer.php
@@ -143,15 +143,18 @@ class InterfaceContainer extends ObjRuleContainer
         $this->o[] = $if;
         $if->addReference($this);
 
-        if( $this->xmlroot === null )
+        if( get_class( $this->owner ) !== "SecureWebGateway" )
         {
-            $importRoot = DH::findFirstElementOrCreate('import', $this->owner->xmlroot);
-            $networkRoot = DH::findFirstElementOrCreate('network', $importRoot);
-            $this->xmlroot = DH::findFirstElementOrCreate('interface', $networkRoot);
+            if( $this->xmlroot === null )
+            {
+                $importRoot = DH::findFirstElementOrCreate('import', $this->owner->xmlroot);
+                $networkRoot = DH::findFirstElementOrCreate('network', $importRoot);
+                $this->xmlroot = DH::findFirstElementOrCreate('interface', $networkRoot);
+            }
+
+            DH::createElement($this->xmlroot, 'member', $if->name());
         }
 
-
-        DH::createElement($this->xmlroot, 'member', $if->name());
 
         return TRUE;
     }

--- a/lib/network-classes/InterfaceContainer.php
+++ b/lib/network-classes/InterfaceContainer.php
@@ -33,7 +33,7 @@ class InterfaceContainer extends ObjRuleContainer
     public $owner;
 
     /**
-     * @param VirtualSystem|DeviceCloud|Zone|VirtualRouter|PbfRule|DoSRule|DHCP $owner
+     * @param VirtualSystem|DeviceCloud|Zone|VirtualRouter|PbfRule|DoSRule|DHCP|SecureWebGateway $owner
      * @param NetworkPropertiesContainer $centralStore
      */
     public function __construct($owner, $centralStore)

--- a/lib/network-classes/LoopbackInterface.php
+++ b/lib/network-classes/LoopbackInterface.php
@@ -142,6 +142,93 @@ class LoopbackInterface
 
     }
 
+    public function referencedObjectRenamed($h, $old)
+    {
+        if( is_object($h) )
+        {
+            if( get_class( $h ) == "Address" )
+            {
+                //Text replace
+                $qualifiedNodeName = '//*[text()="'.$old.'"]';
+                $xpathResult = DH::findXPath( $qualifiedNodeName, $this->xmlroot);
+                foreach( $xpathResult as $node )
+                    $node->textContent = $h->name();
+
+
+                //attribute replace
+                $nameattribute = $old;
+                $qualifiedNodeName = "entry";
+                $nodeList = $this->xmlroot->getElementsByTagName($qualifiedNodeName);
+                $nodeArray = iterator_to_array($nodeList);
+                foreach( $nodeArray as $item )
+                {
+                    if ($nameattribute !== null)
+                    {
+                        $XMLnameAttribute = DH::findAttribute("name", $item);
+                        if ($XMLnameAttribute === FALSE)
+                            continue;
+
+                        if ($XMLnameAttribute !== $nameattribute)
+                            continue;
+                    }
+                    $item->setAttribute('name', $h->name());
+                }
+            }
+
+            return;
+        }
+
+        mwarning("object is not part of this Tunnel Interface : {$h->toString()}");
+    }
+
+    public function replaceReferencedObject($old, $new)
+    {
+        /*
+        if( $old === $new )
+            return FALSE;
+
+        $pos = array_search($old, $this->o, TRUE);
+
+        if( $pos !== FALSE )
+        {
+            while( $pos !== FALSE )
+            {
+                unset($this->o[$pos]);
+                $pos = array_search($old, $this->o, TRUE);
+            }
+
+            if( $new !== null && !$this->has($new->name()) )
+            {
+                $this->o[] = $new;
+                $new->addReference($this);
+            }
+            $old->removeReference($this);
+
+            if( $new === null || $new->name() != $old->name() )
+                $this->rewriteXML();
+
+            return TRUE;
+        }
+        #elseif( !$this->isDynamic() )
+        #    mwarning("object is not part of this group: " . $old->toString());
+        */
+
+
+        return FALSE;
+    }
+
+    public function API_replaceReferencedObject($old, $new)
+    {
+        $ret = $this->replaceReferencedObject($old, $new);
+
+        if( $ret )
+        {
+            $this->API_sync();
+        }
+
+        return $ret;
+    }
+
     /**
      * @return string
      */

--- a/lib/network-classes/NetworkPropertiesContainer.php
+++ b/lib/network-classes/NetworkPropertiesContainer.php
@@ -57,6 +57,9 @@ class NetworkPropertiesContainer
     /** @var virtualWireStore */
     public $virtualWireStore;
 
+    /** @var SecureWebGateway */
+    public $secureWebGateway;
+
     /** @var DOMElement|null */
     public $xmlroot = null;
 
@@ -83,6 +86,8 @@ class NetworkPropertiesContainer
         $this->tunnelIfStore = new TunnelIfStore('TunnelIfaces', $owner);
         $this->virtualWireStore = new VirtualWireStore('', $owner);
         $this->dhcpStore = new DHCPStore('DHCP', $owner);
+        $this->secureWebGateway = new SecureWebGateway('SecurityWebGateway', $owner);
+
 
         $this->sharedGatewayStore = new SharedGatewayStore('SharedGateway', $owner);
     }
@@ -172,6 +177,11 @@ class NetworkPropertiesContainer
 
         }
 
+        $tmp = DH::findFirstElement('secure-web-gateway', $this->xmlroot);
+        if( $tmp !== FALSE )
+        {
+            $this->secureWebGateway->load_from_domxml($tmp);
+        }
     }
 
     function load_from_domxml_2(DOMElement $xml)

--- a/lib/network-classes/SecureWebGateway.php
+++ b/lib/network-classes/SecureWebGateway.php
@@ -59,11 +59,12 @@ class SecureWebGateway
         $this->owner = $owner;
         $this->name = $name;
 
-        if( isset($owner->network) )
+        if( get_class($owner) !== "PanoramaConf" )
         {
             $this->localInterface = new InterfaceContainer($this, $owner->network);
             $this->upstreamInterface = new InterfaceContainer($this, $owner->network);
         }
+
 
     }
 
@@ -89,21 +90,8 @@ class SecureWebGateway
         if( $this->type !== null )
         {
             $tmp_type = DH::findFirstElement($this->type, $xml);
-            if( $tmp_type !== null )
+            if( $tmp_type !== False )
             {
-                /*
-                <explicit-web-gateway>
-                    <proxy-ip>
-                       <ipv4>10.10.0.254/24</ipv4>
-                    </proxy-ip>
-                    <interface>ethernet1/2</interface>
-                    <upstream-interface>loopback.1</upstream-interface>
-                    <dns-proxy>DNS_proxy</dns-proxy>
-                    <log-setting>default</log-setting>
-                    <authentication-method>none</authentication-method>
-                    <sni-dest-check>no</sni-dest-check>
-                 </explicit-web-gateway>
-                 */
                 $interface = DH::findFirstElement('interface', $tmp_type);
                 $tmpInterface = $this->owner->network->findInterface( $interface->textContent );
                 $this->localInterface->addInterface( $tmpInterface );

--- a/lib/network-classes/SecureWebGateway.php
+++ b/lib/network-classes/SecureWebGateway.php
@@ -59,8 +59,12 @@ class SecureWebGateway
         $this->owner = $owner;
         $this->name = $name;
 
-        $this->localInterface = new InterfaceContainer($this, $owner->network);
-        $this->upstreamInterface = new InterfaceContainer($this, $owner->network);
+        if( isset($owner->network) )
+        {
+            $this->localInterface = new InterfaceContainer($this, $owner->network);
+            $this->upstreamInterface = new InterfaceContainer($this, $owner->network);
+        }
+
     }
 
     /**

--- a/lib/network-classes/SecureWebGateway.php
+++ b/lib/network-classes/SecureWebGateway.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * ISC License
+ *
+ * Copyright (c) 2014-2018, Palo Alto Networks Inc.
+ * Copyright (c) 2019, Palo Alto Networks Inc.
+ * Copyright (c) 2024, Sven Waschkut - pan-os-php@waschkut.net
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/**
+ * Class SecureWebGateway
+ * @property NetworkPropertiesContainer $owner
+ */
+class SecureWebGateway
+{
+    use InterfaceType;
+    use XmlConvertible;
+    use PathableName;
+    use ReferenceableObject;
+
+    public $owner;
+
+    public $localInterface;
+    public $upstreamInterface;
+
+    public $enablement;
+
+    public $type = null;
+
+    /** @var null|string[]|DOMElement */
+    public $gateway = 'notfound';
+
+    /** @var null|string[]|DOMElement */
+    public $protocol = 'notfound';
+    /** @var null|string[]|DOMElement */
+
+
+
+    /**
+     * SecureWebGateway constructor.
+     * @param string $name
+     * @param PANConf|PanoramaConf $owner
+     */
+    public function __construct($name, $owner)
+    {
+        $this->owner = $owner;
+        $this->name = $name;
+
+        $this->localInterface = new InterfaceContainer($this, $owner->network);
+        $this->upstreamInterface = new InterfaceContainer($this, $owner->network);
+    }
+
+    /**
+     * @param DOMElement $xml
+     */
+    public function load_from_domxml($xml)
+    {
+        $this->xmlroot = $xml;
+
+        $tmp_enablement = DH::findFirstElement('enablement', $xml);
+        $tmp_explicit_proxy = DH::findFirstElement('explicit-proxy', $tmp_enablement);
+        if( $tmp_explicit_proxy !== null && $tmp_explicit_proxy !== false )
+        {
+            $this->type = "explicit-web-gateway";
+        }
+        else
+        {
+            DH::DEBUGprintDOMDocument($tmp_enablement);
+            mwarning( "SecureWebGateway type not yet implemented", null, false );
+        }
+
+        if( $this->type !== null )
+        {
+            $tmp_type = DH::findFirstElement($this->type, $xml);
+            if( $tmp_type !== null )
+            {
+                /*
+                <explicit-web-gateway>
+                    <proxy-ip>
+                       <ipv4>10.10.0.254/24</ipv4>
+                    </proxy-ip>
+                    <interface>ethernet1/2</interface>
+                    <upstream-interface>loopback.1</upstream-interface>
+                    <dns-proxy>DNS_proxy</dns-proxy>
+                    <log-setting>default</log-setting>
+                    <authentication-method>none</authentication-method>
+                    <sni-dest-check>no</sni-dest-check>
+                 </explicit-web-gateway>
+                 */
+                $interface = DH::findFirstElement('interface', $tmp_type);
+                $tmpInterface = $this->owner->network->findInterface( $interface->textContent );
+                $this->localInterface->addInterface( $tmpInterface );
+                $tmpInterface->addReference( $this->localInterface );
+
+                $upstream_interface = DH::findFirstElement('upstream-interface', $tmp_type);
+                $tmpInterface = $this->owner->network->findInterface( $upstream_interface->textContent );
+                $this->upstreamInterface->addInterface( $tmpInterface );
+                $tmpInterface->addReference( $this->upstreamInterface );
+            }
+        }
+    }
+
+    public function isSecureWebProxyType()
+    {
+        return TRUE;
+    }
+
+
+    static public $templatexml = '<entry name="**temporarynamechangeme**">
+    </entry>';
+
+}

--- a/lib/network-classes/StaticRoute.php
+++ b/lib/network-classes/StaticRoute.php
@@ -346,13 +346,22 @@ class StaticRoute
         return $this->_nexthopType;
     }
 
-    public function referencedObjectRenamed($h)
+    public function referencedObjectRenamed($h, $old)
     {
-        if( $this->_interface === $h )
+        if( get_class($h) == "EthernetInterface" )
         {
-            $this->_interface = $h;
-            $this->rewriteInterface_XML();
+            if( $this->_interface !== $h )
+            {
+                //why set it again????
+                $this->_interface = $h;
 
+                $this->rewriteInterface_XML();
+
+                return;
+            }
+        }
+        elseif( get_class($h) == "Address" )
+        {
             return;
         }
 

--- a/lib/network-classes/StaticRoute.php
+++ b/lib/network-classes/StaticRoute.php
@@ -456,4 +456,22 @@ class StaticRoute
 
         return $text;
     }
+
+    public function replaceReferencedObject($old, $new)
+    {
+        $this->referencedObjectRenamed($new, $old->name());
+        return true;
+    }
+
+    public function API_replaceReferencedObject($old, $new)
+    {
+        $ret = $this->replaceReferencedObject($old, $new);
+
+        if( $ret )
+        {
+            $this->API_sync();
+        }
+
+        return $ret;
+    }
 }

--- a/lib/network-classes/StaticRoute.php
+++ b/lib/network-classes/StaticRoute.php
@@ -71,23 +71,6 @@ class StaticRoute
     {
         $this->xmlroot = $xml;
 
-        //<entry name="Route 161">
-            //<nexthop><ip-address>10.34.111.1</ip-address></nexthop>
-            //<metric>10</metric>
-            //<interface>Port-channel22.511</interface>
-            //<destination>192.168.220.70/32</destination>
-        //</entry>
-
-        /*
-        <entry name="test">
-          <nexthop><ip-address>Route_6.7.8.9</ip-address></nexthop>
-          <bfd><profile>None</profile></bfd>
-          <metric>10</metric>
-          <destination>Route_DST_192.168.10.0m24</destination>
-          <route-table><unicast/></route-table>
-        </entry>
-         */
-
         $this->name = DH::findAttribute('name', $xml);
         if( $this->name === FALSE )
             derr("static-route name not found\n");
@@ -362,6 +345,32 @@ class StaticRoute
         }
         elseif( get_class($h) == "Address" )
         {
+            //Text replace
+            $qualifiedNodeName = '//*[text()="'.$old.'"]';
+            $xpathResult = DH::findXPath( $qualifiedNodeName, $this->xmlroot);
+            foreach( $xpathResult as $node )
+                $node->textContent = $h->name();
+
+
+            //attribute replace
+            $nameattribute = $old;
+            $qualifiedNodeName = "entry";
+            $nodeList = $this->xmlroot->getElementsByTagName($qualifiedNodeName);
+            $nodeArray = iterator_to_array($nodeList);
+            foreach( $nodeArray as $item )
+            {
+                if ($nameattribute !== null)
+                {
+                    $XMLnameAttribute = DH::findAttribute("name", $item);
+                    if ($XMLnameAttribute === FALSE)
+                        continue;
+
+                    if ($XMLnameAttribute !== $nameattribute)
+                        continue;
+                }
+                $item->setAttribute('name', $h->name());
+            }
+
             return;
         }
 

--- a/lib/network-classes/TunnelInterface.php
+++ b/lib/network-classes/TunnelInterface.php
@@ -139,6 +139,93 @@ class TunnelInterface
 
     }
 
+    public function referencedObjectRenamed($h, $old)
+    {
+        if( is_object($h) )
+        {
+            if( get_class( $h ) == "Address" )
+            {
+                //Text replace
+                $qualifiedNodeName = '//*[text()="'.$old.'"]';
+                $xpathResult = DH::findXPath( $qualifiedNodeName, $this->xmlroot);
+                foreach( $xpathResult as $node )
+                    $node->textContent = $h->name();
+
+
+                //attribute replace
+                $nameattribute = $old;
+                $qualifiedNodeName = "entry";
+                $nodeList = $this->xmlroot->getElementsByTagName($qualifiedNodeName);
+                $nodeArray = iterator_to_array($nodeList);
+                foreach( $nodeArray as $item )
+                {
+                    if ($nameattribute !== null)
+                    {
+                        $XMLnameAttribute = DH::findAttribute("name", $item);
+                        if ($XMLnameAttribute === FALSE)
+                            continue;
+
+                        if ($XMLnameAttribute !== $nameattribute)
+                            continue;
+                    }
+                    $item->setAttribute('name', $h->name());
+                }
+            }
+
+            return;
+        }
+
+        mwarning("object is not part of this Tunnel Interface : {$h->toString()}");
+    }
+
+    public function replaceReferencedObject($old, $new)
+    {
+        /*
+        if( $old === $new )
+            return FALSE;
+
+        $pos = array_search($old, $this->o, TRUE);
+
+        if( $pos !== FALSE )
+        {
+            while( $pos !== FALSE )
+            {
+                unset($this->o[$pos]);
+                $pos = array_search($old, $this->o, TRUE);
+            }
+
+            if( $new !== null && !$this->has($new->name()) )
+            {
+                $this->o[] = $new;
+                $new->addReference($this);
+            }
+            $old->removeReference($this);
+
+            if( $new === null || $new->name() != $old->name() )
+                $this->rewriteXML();
+
+            return TRUE;
+        }
+        #elseif( !$this->isDynamic() )
+        #    mwarning("object is not part of this group: " . $old->toString());
+        */
+
+
+        return FALSE;
+    }
+
+    public function API_replaceReferencedObject($old, $new)
+    {
+        $ret = $this->replaceReferencedObject($old, $new);
+
+        if( $ret )
+        {
+            $this->API_sync();
+        }
+
+        return $ret;
+    }
+
     /**
      * @return string
      */

--- a/lib/network-classes/TunnelInterface.php
+++ b/lib/network-classes/TunnelInterface.php
@@ -180,38 +180,8 @@ class TunnelInterface
 
     public function replaceReferencedObject($old, $new)
     {
-        /*
-        if( $old === $new )
-            return FALSE;
-
-        $pos = array_search($old, $this->o, TRUE);
-
-        if( $pos !== FALSE )
-        {
-            while( $pos !== FALSE )
-            {
-                unset($this->o[$pos]);
-                $pos = array_search($old, $this->o, TRUE);
-            }
-
-            if( $new !== null && !$this->has($new->name()) )
-            {
-                $this->o[] = $new;
-                $new->addReference($this);
-            }
-            $old->removeReference($this);
-
-            if( $new === null || $new->name() != $old->name() )
-                $this->rewriteXML();
-
-            return TRUE;
-        }
-        #elseif( !$this->isDynamic() )
-        #    mwarning("object is not part of this group: " . $old->toString());
-        */
-
-
-        return FALSE;
+        $this->referencedObjectRenamed($new, $old->name());
+        return true;
     }
 
     public function API_replaceReferencedObject($old, $new)

--- a/lib/network-classes/VlanInterface.php
+++ b/lib/network-classes/VlanInterface.php
@@ -197,6 +197,24 @@ class VlanInterface
         mwarning("object is not part of this Tunnel Interface : {$h->toString()}");
     }
 
+    public function replaceReferencedObject($old, $new)
+    {
+        $this->referencedObjectRenamed($new, $old->name());
+        return true;
+    }
+
+    public function API_replaceReferencedObject($old, $new)
+    {
+        $ret = $this->replaceReferencedObject($old, $new);
+
+        if( $ret )
+        {
+            $this->API_sync();
+        }
+
+        return $ret;
+    }
+
     /**
      * @return string
      */

--- a/lib/network-classes/VlanInterface.php
+++ b/lib/network-classes/VlanInterface.php
@@ -156,6 +156,47 @@ class VlanInterface
 
     }
 
+    public function referencedObjectRenamed($h, $old)
+    {
+        if( is_object($h) )
+        {
+            if( get_class( $h ) == "Address" )
+            {
+                //Text replace
+                $qualifiedNodeName = '//*[text()="'.$old.'"]';
+                $xpathResult = DH::findXPath( $qualifiedNodeName, $this->xmlroot);
+                foreach( $xpathResult as $node )
+                    $node->textContent = $h->name();
+
+
+                //attribute replace
+                $nameattribute = $old;
+                $qualifiedNodeName = "entry";
+                $nodeList = $this->xmlroot->getElementsByTagName($qualifiedNodeName);
+                $nodeArray = iterator_to_array($nodeList);
+
+                $templateEntryArray = array();
+                foreach( $nodeArray as $item )
+                {
+                    if ($nameattribute !== null)
+                    {
+                        $XMLnameAttribute = DH::findAttribute("name", $item);
+                        if ($XMLnameAttribute === FALSE)
+                            continue;
+
+                        if ($XMLnameAttribute !== $nameattribute)
+                            continue;
+                    }
+                    $item->setAttribute('name', $h->name());
+                }
+            }
+
+            return;
+        }
+
+        mwarning("object is not part of this Tunnel Interface : {$h->toString()}");
+    }
+
     /**
      * @return string
      */

--- a/lib/object-classes/AntiSpywareProfile.php
+++ b/lib/object-classes/AntiSpywareProfile.php
@@ -353,7 +353,12 @@ class AntiSpywareProfile extends SecurityProfile2
                     $name = DH::findAttribute("name", $tmp_entry1);
                     $action_element = DH::findFirstElement("action", $tmp_entry1);
                     if( $action_element !== FALSE )
-                        $this->additional['botnet-domain']['lists'][$name]['action'] = $action_element->firstElementChild->nodeName;
+                    {
+                        $tmp_firstElement = $action_element->firstElementChild;
+                        if( $tmp_firstElement !== FALSE && $tmp_firstElement !== null )
+                            $this->additional['botnet-domain']['lists'][$name]['action'] = $action_element->firstElementChild->nodeName;
+                    }
+
                     $tmp_packet_capture = DH::findFirstElement("packet-capture", $tmp_entry1);
                     if( $tmp_packet_capture !== FALSE )
                         $this->additional['botnet-domain']['lists'][$name]['packet-capture'] = $tmp_packet_capture->textContent;

--- a/lib/object-classes/App.php
+++ b/lib/object-classes/App.php
@@ -221,6 +221,9 @@ class App
             if( $app->isApplicationFilter() )
                 continue;
 
+            if( isset( $this->exclude[$app->name()] ) )
+                continue;
+
             $hasCategory = TRUE;
             if( count( $categories ) > 0 )
             {
@@ -713,7 +716,7 @@ class App
         if( $returnString )
             $app_mapping[] = $this->name().",".$string_category.",".$string_subcategory.",".$string_technology.",".$string_risk.",".$string_apptag.",".$string_characteristic;
         else
-            $app_mapping[] = array( "name" => $this->name(), "category" => $string_category, "subcatecory" => $string_subcategory, "technology" => $string_technology, "risk" => $string_risk, "tag" => $string_apptag, "characteristic" => $string_characteristic );
+            $app_mapping[] = array( "name" => $this->name(), "category" => $string_category, "subcategory" => $string_subcategory, "technology" => $string_technology, "risk" => $string_risk, "tag" => $string_apptag, "characteristic" => $string_characteristic );
     }
 
     function getAppServiceDefault( $secure = false, &$port_mapping_text = array(), &$subarray = array() )
@@ -804,6 +807,85 @@ class App
             //$subarray[$this->name()]['icmpcode'] = $this->icmpcode;
             $subarray[$this->name()]['tcp'] = $this->icmpcode;
         */
+    }
+
+    function spreadsheetContainerGroupFilter( $context, $count, $count1, &$lines)
+    {
+        /** @var App $object */
+        if( $count % 2 == 1 )
+            $lines .= "<tr>\n";
+        else
+            $lines .= "<tr bgcolor=\"#DDDDDD\">";
+
+        $lines .= $context->encloseFunction( "" );
+        $lines .= $context->encloseFunction( (string)$count1 );
+
+        $lines .= $context->encloseFunction( $this->type() );
+
+        $objType = "application";
+        if( $this->isContainer() )
+            $objType = "container";
+        elseif( $this->isApplicationCustom() )
+            $objType = "application-custom";
+        elseif( $this->isApplicationGroup() )
+            $objType = "application-group";
+        elseif( $this->isApplicationFilter() )
+            $objType = "application-filter";
+
+        $lines .= $context->encloseFunction( $objType );
+
+        if( isset($this->owner) && isset($this->owner->owner) )
+        {
+            if($this->owner->owner->isPanorama() || $this->owner->owner->isFirewall() )
+                $lines .= $context->encloseFunction('shared');
+            else
+                $lines .= $context->encloseFunction($this->owner->owner->name());
+        }
+        else
+            $lines .= $context->encloseFunction("---");
+
+        $lines .= $context->encloseFunction($this->name());
+    }
+
+    function spreadsheetAppDetails( $context, &$lines)
+    {
+        $lines .= $context->encloseFunction( $this->category);
+
+        $lines .= $context->encloseFunction( $this->subCategory);
+
+        $lines .= $context->encloseFunction( $this->risk);
+
+        $lines .= $context->encloseFunction( $this->technology);
+
+        $lines .= $context->encloseFunction( $this->apptag);
+
+        $tmp = array_keys( $this->_characteristics );
+        $lines .= $context->encloseFunction( $tmp);
+
+        $port_mapping_text = array();
+        $subArray = array();
+        $this->getAppServiceDefault( false, $port_Mapping_text, $subArray);
+        $lines .= $context->encloseFunction( $port_Mapping_text);
+
+        $array = array();
+        if( isset($this->timeout) )
+            $array[] = "tcp_timeout:".$this->timeout;
+        else
+            $array[] = "tcp_timeout: 3600";
+        if( isset($this->tcp_half_closed_timeout) )
+            $array[] = "tcp_half_closed:".$this->tcp_half_closed_timeout;
+        else
+            $array[] = "tcp_half_closed: 120";
+        if( isset($this->tcp_time_wait_timeout) )
+            $array[] = "tcp_time_wait:".$this->tcp_time_wait_timeout;
+        else
+            $array[] = "tcp_time_wait: 15";
+        $lines .= $context->encloseFunction( $array);
+
+        $lines .= $context->encloseFunction( array() );
+
+
+
     }
 }
 

--- a/lib/object-classes/AppFilter.php
+++ b/lib/object-classes/AppFilter.php
@@ -67,6 +67,8 @@ class AppFilter extends App
     public $tagging;
     public $risk;
 
+    public $exclude;
+
     /**
      * @return string
      */
@@ -119,68 +121,6 @@ class AppFilter extends App
                 }
             }
         }
-        /*
-        $tmp = DH::findFirstElement('category', $appx);
-        if( $tmp !== FALSE )
-        {
-            $this->app_filter_details['category'] = array();
-            foreach( $tmp->childNodes as $tmp1 )
-            {
-                if( $tmp1->nodeType != XML_ELEMENT_NODE ) continue;
-                $this->category = $tmp1->textContent;
-                $this->app_filter_details['category'][$tmp1->textContent] = $tmp1->textContent;
-
-            }
-        }
-
-        $tmp = DH::findFirstElement('subcategory', $appx);
-        if( $tmp !== FALSE )
-        {
-            $this->app_filter_details['subcategory'] = array();
-            foreach( $tmp->childNodes as $tmp1 )
-            {
-                if( $tmp1->nodeType != XML_ELEMENT_NODE ) continue;
-                $this->subCategory = $tmp1->textContent;
-                $this->app_filter_details['subcategory'][$tmp1->textContent] = $tmp1->textContent;
-            }
-        }
-
-        $tmp = DH::findFirstElement('technology', $appx);
-        if( $tmp !== FALSE )
-        {
-            $this->app_filter_details['technology'] = array();
-            foreach( $tmp->childNodes as $tmp1 )
-            {
-                if( $tmp1->nodeType != XML_ELEMENT_NODE ) continue;
-                $this->technology = $tmp1->textContent;
-                $this->app_filter_details['technology'][$tmp1->textContent] = $tmp1->textContent;
-            }
-        }
-
-        $tmp = DH::findFirstElement('risk', $appx);
-        if( $tmp !== FALSE )
-        {
-            $this->app_filter_details['risk'] = array();
-            foreach( $tmp->childNodes as $tmp1 )
-            {
-                if( $tmp1->nodeType != XML_ELEMENT_NODE ) continue;
-                $this->risk = $tmp1->textContent;
-                $this->app_filter_details['risk'][$tmp1->textContent] = $tmp1->textContent;
-            }
-        }
-
-        $tmp = DH::findFirstElement('tag', $appx);
-        if( $tmp !== FALSE )
-        {
-            $this->app_filter_details['tag'] = array();
-            foreach( $tmp->childNodes as $tmp1 )
-            {
-                if( $tmp1->nodeType != XML_ELEMENT_NODE ) continue;
-                $this->technology = $tmp1->textContent;
-                $this->app_filter_details['tag'][$tmp1->textContent] = $tmp1->textContent;
-            }
-        }
-        */
 
 
         #$arry = array( 'evasive', 'excessive-bandwidth-use', 'used-by-malware', 'transfers-files', 'has-known-vulnerabilities', 'tunnels-other-apps', 'prone-to-misuse', 'pervasive'  );
@@ -233,6 +173,19 @@ class AppFilter extends App
         {
             if( $tmp->textContent == 'yes' )
                 $this->_characteristics['widely-used'] = TRUE;
+        }
+
+        //////////
+        $tmp = DH::findFirstElement('exclude', $appx);
+        if( $tmp !== FALSE )
+        {
+            foreach( $tmp->childNodes as $tmp1 )
+            {
+                if ($tmp1->nodeType != XML_ELEMENT_NODE)
+                    continue;
+
+                $this->exclude[$tmp1->textContent] = $tmp1->textContent;
+            }
         }
     }
 }

--- a/lib/object-classes/EDL.php
+++ b/lib/object-classes/EDL.php
@@ -133,9 +133,11 @@ class EDL
 
 
             $tmp_recurring_node = DH::findFirstElement('recurring', $tmp_type);
-            if ($tmp_recurring_node != False) {
+            if ($tmp_recurring_node != False)
+            {
                 $tmp_recurring = DH::firstChildElement($tmp_recurring_node);
-                $this->recurring = $tmp_recurring->nodeName;
+                if ($tmp_recurring != False)
+                    $this->recurring = $tmp_recurring->nodeName;
             }
 
             $tmp_url_node = DH::findFirstElement('url', $tmp_type);

--- a/lib/object-classes/VulnerabilityProfile.php
+++ b/lib/object-classes/VulnerabilityProfile.php
@@ -172,10 +172,13 @@ class VulnerabilityProfile extends SecurityProfile2
                 if( $action !== FALSE )
                 {
                     $tmp_action = DH::firstChildElement($action);
-                    $tmp_array[$this->secprof_type][$this->name]['threat-exception'][$tmp_name]['action'] = $tmp_action->nodeName;
-                    $this->threatException[$tmp_name]['action'] = $tmp_action->nodeName;
-                    if($threat_obj !== null)
-                        $this->threatException[$tmp_name]['default-action'] = $threat_obj->defaultAction();
+                    if( $tmp_action !== FALSE )
+                    {
+                        $tmp_array[$this->secprof_type][$this->name]['threat-exception'][$tmp_name]['action'] = $tmp_action->nodeName;
+                        $this->threatException[$tmp_name]['action'] = $tmp_action->nodeName;
+                        if($threat_obj !== null)
+                            $this->threatException[$tmp_name]['default-action'] = $threat_obj->defaultAction();
+                    }
                 }
 
                 $exemptIP = DH::findFirstElement('exempt-ip', $tmp_entry1);

--- a/lib/object-classes/trait/AddressCommon.php
+++ b/lib/object-classes/trait/AddressCommon.php
@@ -554,36 +554,26 @@ trait AddressCommon
                     (get_class($objectRef) == "StaticRoute")
                 )
                 {
-                    //This is only changeing the XML,
-                    $objectRef->referencedObjectRenamed($withObject, $this->name());
-                    PH::print_stdout( $outputPadding . "- replacing in {$objectRef->toString()}" );
 
-                    //Todo: swaschkut 20250110 - is it needed to change object reference??
-                    /*
-                    if( get_class($objectRef->owner->owner) === "PANConf" )
+                    if( isset($objectRef->owner->owner) && $objectRef->owner->owner !== null )
                     {
-                        if( isset( $objectRef->owner->owner->owner ) )
+                        $class = $objectRef->owner->owner;
+                        $classTxt = get_class($class);
+
+                        if( $classTxt == "PANConf" )
                         {
-                            PH::print_stdout( "- SKIP: not yet possible on ".get_class($objectRef) );
-                            $success = false;
-                            $success2 = false;
-                            continue;
+                            if( isset( $objectRef->owner->owner->owner ) and get_class($objectRef->owner->owner->owner) == "Template" )
+                            {
+                                $class = $objectRef->owner->owner->owner;
+                                $classTxt = get_class($class);
+
+                                if( $classTxt == "Template" )
+                                    $class = $class->owner;
+                            }
                         }
-                        else
-                        {
-                            /** @var PANConf $panConf */
-                    /*
-                            $panConf = $objectRef->owner->owner;
-                            $tmp_vsys1 = $panConf->findVirtualSystem("vsys1");
-                            $tmp_store = $tmp_vsys1->addressStore;
-                        }
+
+                        $tmp_store = $class->addressStore;
                     }
-                    elseif( get_class($objectRef->owner->owner) === "VirtualSystem" )
-                    {
-                        $tmp_store = $objectRef->owner->owner->addressStore;
-                    }
-                     */
-                    continue;
                 }
                 else
                 {

--- a/lib/object-classes/trait/AddressCommon.php
+++ b/lib/object-classes/trait/AddressCommon.php
@@ -554,9 +554,35 @@ trait AddressCommon
                     (get_class($objectRef) == "StaticRoute")
                 )
                 {
-                    PH::print_stdout( "- SKIP: not yet possible on ".get_class($objectRef) );
-                    $success = false;
-                    $success2 = false;
+                    //This is only changeing the XML,
+                    $objectRef->referencedObjectRenamed($withObject, $this->name());
+                    PH::print_stdout( $outputPadding . "- replacing in {$objectRef->toString()}" );
+
+                    //Todo: swaschkut 20250110 - is it needed to change object reference??
+                    /*
+                    if( get_class($objectRef->owner->owner) === "PANConf" )
+                    {
+                        if( isset( $objectRef->owner->owner->owner ) )
+                        {
+                            PH::print_stdout( "- SKIP: not yet possible on ".get_class($objectRef) );
+                            $success = false;
+                            $success2 = false;
+                            continue;
+                        }
+                        else
+                        {
+                            /** @var PANConf $panConf */
+                    /*
+                            $panConf = $objectRef->owner->owner;
+                            $tmp_vsys1 = $panConf->findVirtualSystem("vsys1");
+                            $tmp_store = $tmp_vsys1->addressStore;
+                        }
+                    }
+                    elseif( get_class($objectRef->owner->owner) === "VirtualSystem" )
+                    {
+                        $tmp_store = $objectRef->owner->owner->addressStore;
+                    }
+                     */
                     continue;
                 }
                 else
@@ -573,7 +599,6 @@ trait AddressCommon
                 }
 
                 #template <tunnel><units><entry name="tunnel.1"><ip>
-
 
                 $tmp_addr = $tmp_store->find( $withObject->name() );
                 if( $tmp_addr !== null )

--- a/lib/object-classes/trait/AddressCommon.php
+++ b/lib/object-classes/trait/AddressCommon.php
@@ -546,9 +546,8 @@ trait AddressCommon
                     (get_class($objectRef) == "EthernetInterface") or
                     (get_class($objectRef) == "VlanInterface") or
 
-                    //Todo: missing address references
-                    (get_class($objectRef) == "GRETunnel") or
 
+                    (get_class($objectRef) == "GreTunnel") or
                     (get_class($objectRef) == "IKEGateway") or
                     (get_class($objectRef) == "GPPortal") or
                     (get_class($objectRef) == "GPGateway") or

--- a/lib/pan_php_framework.php
+++ b/lib/pan_php_framework.php
@@ -358,6 +358,8 @@ require_once $basedir . '/network-classes/SharedGatewayStore.php';
 require_once $basedir . '/network-classes/Certificate.php';
 require_once $basedir . '/network-classes/CertificateStore.php';
 
+require_once $basedir . '/network-classes/SecureWebGateway.php';
+
 
 require_once $basedir . '/rule-classes/RuleWithGroupTag.php';
 

--- a/utils/common/AddressCallContext.php
+++ b/utils/common/AddressCallContext.php
@@ -19,10 +19,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+/**
+ * Class AddressCallContext
+ * @property Address|AddressGroup|Region|EDL $object
+ */
 class AddressCallContext extends CallContext
 {
-    /** @var  Address|AddressGroup */
-
     public static $commonActionFunctions = array();
     public static $supportedActions = array();
 

--- a/utils/common/ServiceCallContext.php
+++ b/utils/common/ServiceCallContext.php
@@ -20,6 +20,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+/**
+ * Class ServiceCallContext
+ * @property Service|ServiceGroup $object
+ */
 class ServiceCallContext extends CallContext
 {
     /** @var  Service|ServiceGroup */

--- a/utils/common/actions-application.php
+++ b/utils/common/actions-application.php
@@ -61,7 +61,18 @@ ApplicationCallContext::$supportedActions['display'] = array(
     'MainFunction' => function (ApplicationCallContext $context) {
         $app = $context->object;
 
-        PH::print_stdout( $context->padding . "* " . get_class($app) . " '{$app->name()}' " );
+        $txt_counter = "";
+        $counter = "";
+        if( $app->isContainer() )
+            $counter = count( $app->containerApps() );
+        elseif( $app->isApplicationGroup() )
+            $counter = count( $app->groupApps() );
+        elseif( $app->isApplicationFilter() )
+            $counter = count( $app->filteredApps() );
+
+        if( !empty($counter) )
+            $txt_counter = "app_counter: ".$counter;
+        PH::print_stdout( $context->padding . "* " . get_class($app) . " '{$app->name()}' ".$txt_counter );
         PH::$JSON_TMP['sub']['object'][$app->name()]['name'] = $app->name();
         PH::$JSON_TMP['sub']['object'][$app->name()]['type'] = get_class($app);
 

--- a/utils/common/actions-application.php
+++ b/utils/common/actions-application.php
@@ -382,11 +382,26 @@ ApplicationCallContext::$supportedActions[] = array(
 
                 if( $object->isApplicationFilter() )
                 {
-                    $lines .= $context->encloseFunction($object->app_filter_details['category']);
-                    $lines .= $context->encloseFunction($object->app_filter_details['subcategory']);
-                    $lines .= $context->encloseFunction($object->app_filter_details['risk']);
-                    $lines .= $context->encloseFunction($object->app_filter_details['technology']);
-                    $lines .= $context->encloseFunction($object->app_filter_details['tagging']);
+                    if( isset($object->app_filter_details['category']) )
+                        $lines .= $context->encloseFunction($object->app_filter_details['category']);
+                    else
+                        $lines .= $context->encloseFunction( "--" );
+                    if( isset($object->app_filter_details['subcategory']) )
+                        $lines .= $context->encloseFunction($object->app_filter_details['subcategory']);
+                    else
+                        $lines .= $context->encloseFunction( "--" );
+                    if( isset($object->app_filter_details['risk']) )
+                        $lines .= $context->encloseFunction($object->app_filter_details['risk']);
+                    else
+                        $lines .= $context->encloseFunction( "--" );
+                    if( isset($object->app_filter_details['technology']) )
+                        $lines .= $context->encloseFunction($object->app_filter_details['technology']);
+                    else
+                        $lines .= $context->encloseFunction( "--" );
+                    if( isset($object->app_filter_details['tagging']) )
+                        $lines .= $context->encloseFunction($object->app_filter_details['tagging']);
+                    else
+                        $lines .= $context->encloseFunction( "--" );
 
                     $tmp = array_keys($object->_characteristics);
                     $lines .= $context->encloseFunction($tmp);

--- a/utils/develop/ui/json_array.js
+++ b/utils/develop/ui/json_array.js
@@ -959,7 +959,23 @@ var subjectObject =
                             "input": "input\/panorama-8.0.xml"
                         }
                     },
+                    "is.only.rulestore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
                     "is.addressstore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.only.addressstore": {
                         "Function": {},
                         "arg": false,
                         "ci": {

--- a/utils/develop/ui/json_array.js
+++ b/utils/develop/ui/json_array.js
@@ -950,6 +950,70 @@ var subjectObject =
                             "fString": "(%PROP% rulestore )",
                             "input": "input\/panorama-8.0.xml"
                         }
+                    },
+                    "is.rulestore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.addressstore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.servicestore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.logicalrouterstore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.virtualrouterstore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.tunnelifstore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.gpgatewaystore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.ikegatewaystore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
                     }
                 }
             },
@@ -1144,6 +1208,28 @@ var subjectObject =
             "displayreferences": {
                 "name": "displayReferences",
                 "MainFunction": {}
+            },
+            "exporttoexcel": {
+                "name": "exportToExcel",
+                "MainFunction": {},
+                "GlobalInitFunction": {},
+                "GlobalFinishFunction": {},
+                "args": {
+                    "filename": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    },
+                    "additionalFields": {
+                        "type": "pipeSeparatedList",
+                        "subtype": "string",
+                        "default": "*NONE*",
+                        "choices": [
+                            "WhereUsed",
+                            "UsedInLocation"
+                        ],
+                        "help": "pipe(|) separated list of additional fields (ie: Arg1|Arg2|Arg3...) to include in the report. The following is available:\n  - UsedInLocation : list locations (vsys,dg,shared) where object is used\n  - WhereUsed : list places where object is used (rules, groups ...)\n"
+                    }
+                }
             },
             "move": {
                 "name": "move",

--- a/utils/develop/ui/json_array.js
+++ b/utils/develop/ui/json_array.js
@@ -889,6 +889,24 @@ var subjectObject =
                             "fString": "(%PROP%)",
                             "input": "input\/panorama-8.0.xml"
                         }
+                    },
+                    "is.virtualsystem": {
+                        "Function": {},
+                        "arg": false,
+                        "help": "returns TRUE if object locationtype is Template or TemplateStack",
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.only.virtualsystem": {
+                        "Function": {},
+                        "arg": false,
+                        "help": "returns TRUE if object locationtype is Template or TemplateStack",
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
                     }
                 }
             },
@@ -1158,6 +1176,18 @@ var subjectObject =
                     }
                 }
             },
+            "category": {
+                "operators": {
+                    "eq": {
+                        "Function": {},
+                        "arg": true,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    }
+                }
+            },
             "characteristic": {
                 "operators": {
                     "has": {
@@ -1385,6 +1415,18 @@ var subjectObject =
                         "arg": false,
                         "ci": {
                             "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    }
+                }
+            },
+            "technology": {
+                "operators": {
+                    "eq": {
+                        "Function": {},
+                        "arg": true,
+                        "ci": {
+                            "fString": "(%PROP% evasive) ",
                             "input": "input\/panorama-8.0.xml"
                         }
                     }

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -2047,8 +2047,8 @@ class MERGER extends UTIL
                 }
                 if ($skip3)
                 {
-                    PH::print_stdout("    - SKIP: object name '{$object->_PANC_shortName()}' as one ".$key." ancestor has same name, but different value");
-                    $this->skippedObject($index, $object, $skippedOBJ, " ".$key." ancestor has same name, but different value");
+                    PH::print_stdout("    - SKIP: object name '{$object->_PANC_shortName()}' as one ancestor has same name, but different value");
+                    $this->skippedObject($index, $object, $skippedOBJ, " ancestor has same name, but different value");
                     return FALSE;//continue
                 }
             }

--- a/utils/lib/util_action_filter.json
+++ b/utils/lib/util_action_filter.json
@@ -888,6 +888,24 @@
                             "fString": "(%PROP%)",
                             "input": "input\/panorama-8.0.xml"
                         }
+                    },
+                    "is.virtualsystem": {
+                        "Function": {},
+                        "arg": false,
+                        "help": "returns TRUE if object locationtype is Template or TemplateStack",
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.only.virtualsystem": {
+                        "Function": {},
+                        "arg": false,
+                        "help": "returns TRUE if object locationtype is Template or TemplateStack",
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
                     }
                 }
             },
@@ -1157,6 +1175,18 @@
                     }
                 }
             },
+            "category": {
+                "operators": {
+                    "eq": {
+                        "Function": {},
+                        "arg": true,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    }
+                }
+            },
             "characteristic": {
                 "operators": {
                     "has": {
@@ -1384,6 +1414,18 @@
                         "arg": false,
                         "ci": {
                             "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    }
+                }
+            },
+            "technology": {
+                "operators": {
+                    "eq": {
+                        "Function": {},
+                        "arg": true,
+                        "ci": {
+                            "fString": "(%PROP% evasive) ",
                             "input": "input\/panorama-8.0.xml"
                         }
                     }

--- a/utils/lib/util_action_filter.json
+++ b/utils/lib/util_action_filter.json
@@ -949,6 +949,70 @@
                             "fString": "(%PROP% rulestore )",
                             "input": "input\/panorama-8.0.xml"
                         }
+                    },
+                    "is.rulestore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.addressstore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.servicestore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.logicalrouterstore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.virtualrouterstore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.tunnelifstore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.gpgatewaystore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.ikegatewaystore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
                     }
                 }
             },
@@ -1143,6 +1207,28 @@
             "displayreferences": {
                 "name": "displayReferences",
                 "MainFunction": {}
+            },
+            "exporttoexcel": {
+                "name": "exportToExcel",
+                "MainFunction": {},
+                "GlobalInitFunction": {},
+                "GlobalFinishFunction": {},
+                "args": {
+                    "filename": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    },
+                    "additionalFields": {
+                        "type": "pipeSeparatedList",
+                        "subtype": "string",
+                        "default": "*NONE*",
+                        "choices": [
+                            "WhereUsed",
+                            "UsedInLocation"
+                        ],
+                        "help": "pipe(|) separated list of additional fields (ie: Arg1|Arg2|Arg3...) to include in the report. The following is available:\n  - UsedInLocation : list locations (vsys,dg,shared) where object is used\n  - WhereUsed : list places where object is used (rules, groups ...)\n"
+                    }
+                }
             },
             "move": {
                 "name": "move",

--- a/utils/lib/util_action_filter.json
+++ b/utils/lib/util_action_filter.json
@@ -958,7 +958,23 @@
                             "input": "input\/panorama-8.0.xml"
                         }
                     },
+                    "is.only.rulestore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
                     "is.addressstore": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.only.addressstore": {
                         "Function": {},
                         "arg": false,
                         "ci": {


### PR DESCRIPTION
UTIL:
* type=address | introduce 'filter=(reflocationtype is.virtualsystem)' / is.only.virtualsystem
* type=address | introduce 'filter=(refstore is.rulestore)' / is.only.rulestore
* type=address | introduce 'filter=(refstore is.addressstore)' / is.only.addressstore
* type=application | introduce 'filter=(technology eq XYZ)' /  (category eq XYZ)
* type=application | introduce actions=exporttoexcel:app_name.html
* different network class | improvement to change address object name and change references - same as merging address objects and change ref
* class ReferenceableObject - extend ReferencesStoreValidation | type=address introduce different filter=(refstore is.XYZ
* type=address-merger | final implementation for apimode if network part is using address objects

BUGFIX:
* bugfix | class AntiSpyware / EDL / VulnerabilityProfile

GENERAL:
* class VirtualSystem - ethernet subInterfaces, add address objects references
* introduce class SecureWebGateway | to reference used interfaces
* continue working on SCM - Fawkes/Buckbeak - class Container/DeviceCloud/DeviceOnPrem