### PR TITLE
bugfix: guard missing bp/visibility JSON keys in DNSPolicy ('Undefined array key' crash in type=stats)

### DIFF
--- a/lib/object-classes/DNSPolicy.php
+++ b/lib/object-classes/DNSPolicy.php
@@ -168,6 +168,10 @@ class DNSPolicy
 
         if( $tmp_debug )
             print_r( $check_array );
+
+        if( !isset( $check_array['action'] ) )
+            return TRUE;
+
         foreach( $check_array['action'] as $validate )
         {
             $bp_action = FALSE;
@@ -180,67 +184,83 @@ class DNSPolicy
                 {
                     if( $tmp_debug )
                         print "0) name: ".$name."\n";
-                    foreach( $validate['action'] as $final_action_check )
+
+                    if( isset( $validate['action'] ) )
                     {
-                        if( $tmp_debug )
-                            print "1) action: ".$this->action()." |validate: ".$final_action_check."\n";
-                        if( $this->action() == $final_action_check )
+                        foreach( $validate['action'] as $final_action_check )
                         {
-                            $bp_action = TRUE;
                             if( $tmp_debug )
-                                print "1-0) true\n";
-                            break;
-                        }
-                        else
-                        {
-                            $bp_action = FALSE;
-                            if( $tmp_debug )
-                                print "1-1) false\n";
-                        }
+                                print "1) action: ".$this->action()." |validate: ".$final_action_check."\n";
+                            if( $this->action() == $final_action_check )
+                            {
+                                $bp_action = TRUE;
+                                if( $tmp_debug )
+                                    print "1-0) true\n";
+                                break;
+                            }
+                            else
+                            {
+                                $bp_action = FALSE;
+                                if( $tmp_debug )
+                                    print "1-1) false\n";
+                            }
 
-                    }
-
-
-                    foreach( $validate['packet-capture'] as $final_packet_check )
-                    {
-                        if( $tmp_debug )
-                            print "2) packet: ".$this->packetCapture()." |validate: ".$final_packet_check."\n";
-                        if( $this->packetCapture() == $final_packet_check )
-                        {
-                            $bp_packet = TRUE;
-                            if( $tmp_debug )
-                                print "2-0) true\n";
-                            break;
-                        }
-                        else
-                        {
-                            $bp_packet = FALSE;
-                            if( $tmp_debug )
-                                print "2-1) false\n";
                         }
                     }
+                    else
+                        $bp_action = TRUE;
 
-                    foreach( $validate['log-level'] as $final_loglevel_check )
+
+                    if( isset( $validate['packet-capture'] ) )
                     {
-                        if( $tmp_debug )
-                            print "3) log-level: ".$this->logLevel()." |validate: ".$final_loglevel_check."\n";
-                        $negate_string = "";
-                        if( strpos($final_loglevel_check, '!') !== FALSE )
-                            $negate_string = "!";
-                        if( $negate_string.$this->logLevel == $final_loglevel_check )
+                        foreach( $validate['packet-capture'] as $final_packet_check )
                         {
-                            $bp_loglevel = FALSE;
                             if( $tmp_debug )
-                                print "3-0) false\n";
-                            break;
-                        }
-                        else
-                        {
-                            $bp_loglevel = TRUE;
-                            if( $tmp_debug )
-                                print "3-1) true\n";
+                                print "2) packet: ".$this->packetCapture()." |validate: ".$final_packet_check."\n";
+                            if( $this->packetCapture() == $final_packet_check )
+                            {
+                                $bp_packet = TRUE;
+                                if( $tmp_debug )
+                                    print "2-0) true\n";
+                                break;
+                            }
+                            else
+                            {
+                                $bp_packet = FALSE;
+                                if( $tmp_debug )
+                                    print "2-1) false\n";
+                            }
                         }
                     }
+                    else
+                        $bp_packet = TRUE;
+
+                    if( isset( $validate['log-level'] ) )
+                    {
+                        foreach( $validate['log-level'] as $final_loglevel_check )
+                        {
+                            if( $tmp_debug )
+                                print "3) log-level: ".$this->logLevel()." |validate: ".$final_loglevel_check."\n";
+                            $negate_string = "";
+                            if( strpos($final_loglevel_check, '!') !== FALSE )
+                                $negate_string = "!";
+                            if( $negate_string.$this->logLevel == $final_loglevel_check )
+                            {
+                                $bp_loglevel = FALSE;
+                                if( $tmp_debug )
+                                    print "3-0) false\n";
+                                break;
+                            }
+                            else
+                            {
+                                $bp_loglevel = TRUE;
+                                if( $tmp_debug )
+                                    print "3-1) true\n";
+                            }
+                        }
+                    }
+                    else
+                        $bp_loglevel = TRUE;
 
 
                     if( $bp_action && $bp_packet && $bp_loglevel )
@@ -262,6 +282,10 @@ class DNSPolicy
 
         if( $tmp_debug )
             print_r( $check_array );
+
+        if( !isset( $check_array['action'] ) )
+            return TRUE;
+
         foreach( $check_array['action'] as $validate )
         {
             $bp_action = FALSE;
@@ -403,6 +427,9 @@ class DNSPolicy
     {
         $check_array = $this->spyware_lists_bp_visibility_JSON( "bp");
 
+        if( !isset( $check_array['action'] ) )
+            return TRUE;
+
         foreach( $check_array['action'] as $validate )
         {
             $bp_action = FALSE;
@@ -413,39 +440,49 @@ class DNSPolicy
                 if( $this->name() == $name )
                 {
                     #print "0) name: ".$name."\n";
-                    foreach( $validate['action'] as $final_action_check )
+                    if( isset( $validate['action'] ) )
                     {
-                        #print "1) action: ".$this->action()." |validate: ".$final_action_check."\n";
-                        if( $this->action() == $final_action_check )
+                        foreach( $validate['action'] as $final_action_check )
                         {
-                            $bp_action = TRUE;
-                            #print "1-0) true\n";
-                            break;
-                        }
-                        else
-                        {
-                            $bp_action = FALSE;
-                            #print "1-1) false\n";
-                        }
+                            #print "1) action: ".$this->action()." |validate: ".$final_action_check."\n";
+                            if( $this->action() == $final_action_check )
+                            {
+                                $bp_action = TRUE;
+                                #print "1-0) true\n";
+                                break;
+                            }
+                            else
+                            {
+                                $bp_action = FALSE;
+                                #print "1-1) false\n";
+                            }
 
-                    }
-
-
-                    foreach( $validate['packet-capture'] as $final_packet_check )
-                    {
-                        #print "2) packet: ".$this->packetCapture()." |validate: ".$final_packet_check."\n";
-                        if( $this->packetCapture() == $final_packet_check )
-                        {
-                            $bp_packet = TRUE;
-                            #print "2-0) true\n";
-                            break;
-                        }
-                        else
-                        {
-                            $bp_packet = FALSE;
-                            #print "2-1) false\n";
                         }
                     }
+                    else
+                        $bp_action = TRUE;
+
+
+                    if( isset( $validate['packet-capture'] ) )
+                    {
+                        foreach( $validate['packet-capture'] as $final_packet_check )
+                        {
+                            #print "2) packet: ".$this->packetCapture()." |validate: ".$final_packet_check."\n";
+                            if( $this->packetCapture() == $final_packet_check )
+                            {
+                                $bp_packet = TRUE;
+                                #print "2-0) true\n";
+                                break;
+                            }
+                            else
+                            {
+                                $bp_packet = FALSE;
+                                #print "2-1) false\n";
+                            }
+                        }
+                    }
+                    else
+                        $bp_packet = TRUE;
 
 
                     if( $bp_action && $bp_packet )

--- a/utils/api/v1/bp/bp_sp_panw.json
+++ b/utils/api/v1/bp/bp_sp_panw.json
@@ -170,6 +170,26 @@
                         ]
                     }
                 ]
+            },
+            "visibility": {
+                "action": [
+                    {
+                        "type": [
+                            "pan-dns-sec-adtracking",
+                            "pan-dns-sec-ddns",
+                            "pan-dns-sec-grayware",
+                            "pan-dns-sec-malware",
+                            "pan-dns-sec-phishing",
+                            "pan-dns-sec-proxy",
+                            "pan-dns-sec-recent",
+                            "pan-dns-sec-parked",
+                            "pan-dns-sec-cc"
+                        ],
+                        "log-level": [
+                            "!none"
+                        ]
+                    }
+                ]
             }
         },
         "lists": {


### PR DESCRIPTION
## Summary

`type=stats` and the `dns-security is.visibility` / `is.bestpractice` filters crash with a fatal `Undefined array key` error whenever the BP JSON file (`shadow-bpjsonfile=...`) does not contain the newer optional sections/keys. This PR makes the `DNSPolicy` checks tolerant of missing JSON keys and brings `bp_sp_panw.json` up to date with the `visibility` section.

## Error being fixed

```
* ** ERROR ** * Died on user notice or warning!! Error: Undefined array key "action" on lib/object-classes/DNSPolicy.php:265
* ** ERROR ** * Died on user notice or warning!! Error: Undefined array key "log-level" on lib/object-classes/DNSPolicy.php:223
```

Triggered by e.g.:

```
pan-os-php type=stats in=config.xml shadow-bpjsonfile=bp_sp_panw.json
```

## Root cause

The `spyware.dns.visibility` section currently exists only in `scm_bp_sp_panw.json`. Three functions in `lib/object-classes/DNSPolicy.php` iterate over JSON keys without checking they exist, so any other BP JSON file (including the bundled `bp_sp_panw.json`, or any user-supplied file) causes a fatal error:

| Function | Unguarded key(s) | When it crashes |
|---|---|---|
| `spyware_dns_security_rule_visibility()` | `$check_array['action']` (line 265) | BP JSON has no `spyware.dns.visibility` section — `spyware_dns_bp_visibility_JSON("visibility")` intentionally returns an empty array in that case (its `derr()` is commented out), but the caller did not handle it |
| `spyware_dns_security_rule_bestpractice()` | `action`, `packet-capture`, `log-level` per entry (line 223) | A `dns.bp` entry omits one of these keys — the bundled `bp_sp_panw.json` entries have no `log-level`, so this crash was guaranteed |
| `spyware_lists_bestpractice()` | `action`, `packet-capture` per entry (line 434) | Same pattern for the `lists.bp` section |

## Changes

**`lib/object-classes/DNSPolicy.php`**
- Added `isset()` guards in all three functions, mirroring the guard pattern that `spyware_dns_security_rule_visibility()` already used for its inner loops.
- Semantics: a missing `visibility`/`action` section or a missing per-entry key means that particular check **passes** (`TRUE`), consistent with the functions' existing fall-through behavior. No behavior change for JSON files that define all keys.

**`utils/api/v1/bp/bp_sp_panw.json`**
- Added the `spyware.dns.visibility` section (the `pan-dns-sec-*` category list, identical to the one in `scm_bp_sp_panw.json`) so the visibility filter performs a real evaluation with the bundled PAN-OS BP file instead of just not crashing.

## Verification

Repro setup: a Panorama test config with an anti-spyware profile containing `botnet-domains` DNS security categories (incl. `pan-dns-sec-malware`), attached to an enabled `allow` rule, run against the pre-fix `bp_sp_panw.json` as `shadow-bpjsonfile`:

- **Before:** `type=stats` dies with `Undefined array key "packet-capture"` in `DNSPolicy.php`.
- **After:** `type=stats` and `type=securityprofile securityprofiletype=spyware 'filter=(dns-security is.visibility)'` both run to completion cleanly.
- `php -l` passes; both JSON files validate; the added `visibility` block is byte-identical to the SCM one.