### PR TITLE
Fix VP best-practice action validation

### DIFF
--- a/lib/object-classes/VulnerabilityProfile.php
+++ b/lib/object-classes/VulnerabilityProfile.php
@@ -419,8 +419,7 @@ class VulnerabilityProfile extends SecurityProfile2
                             else
                             {
                                 #print "action_bp false1\n";
-                                #$action_bp = FALSE;
-                                $action_bp = TRUE;
+                                $action_bp = FALSE;
                             }
 
                         }
@@ -501,7 +500,7 @@ class VulnerabilityProfile extends SecurityProfile2
                         return FALSE;
                     }
 
-                    if( $action_check && $packet_bp )
+                    if( $action_bp && $packet_bp )
                         $bp_set = true;
                 }
                 elseif( $bp_array !== "any" )
@@ -752,4 +751,3 @@ class VulnerabilityProfile extends SecurityProfile2
 </entry>';
     
 }
-

--- a/tests/test_vulnerability_best_practice.php
+++ b/tests/test_vulnerability_best_practice.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * ISC License
+ *
+ * Copyright (c) 2026, Sven Waschkut - pan-os-php@waschkut.net
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+require_once dirname(__FILE__) . '/../lib/pan_php_framework.php';
+
+PH::$shadow_bp_jsonfile = array(
+    'vulnerability' => array(
+        'rule' => array(
+            'bp' => array(
+                'severity' => array('any', 'critical', 'high', 'medium'),
+                'action' => array('reset-both', 'drop', 'block-ip'),
+                'packet-capture' => array('single-packet', 'extended-capture'),
+                'category-exclude' => array('brute-force', 'app-id-change')
+            ),
+            'visibility' => array(
+                'severity' => array('any', 'critical', 'high', 'medium', 'low', 'informational'),
+                'action' => array('!allow')
+            )
+        )
+    )
+);
+
+function createVulnerabilityProfileForAction($action)
+{
+    $profile = new VulnerabilityProfile('vp-best-practice-test', null);
+
+    foreach( array('any', 'critical', 'high', 'medium') as $severity )
+    {
+        $rule = new ThreatPolicyVulnerability('rule-' . $severity, $profile);
+        $rule->severity = array($severity => $severity);
+        $rule->action = $action;
+        $rule->packetCapture = 'single-packet';
+        $rule->category = 'any';
+        $rule->host = 'any';
+        $rule->threatname = 'any';
+        $profile->rules_obj[] = $rule;
+    }
+
+    return $profile;
+}
+
+function assertVulnerabilityBestPractice($expected, $action)
+{
+    $actual = createVulnerabilityProfileForAction($action)->vulnerability_rules_best_practice();
+    if( $actual !== $expected )
+    {
+        fwrite(STDERR, "Expected action '{$action}' best-practice result to be " . var_export($expected, true)
+            . ', got ' . var_export($actual, true) . "\n");
+        exit(1);
+    }
+}
+
+assertVulnerabilityBestPractice(true, 'reset-both');
+assertVulnerabilityBestPractice(true, 'drop');
+assertVulnerabilityBestPractice(true, 'block-ip');
+assertVulnerabilityBestPractice(false, 'alert');
+
+print "Vulnerability Protection best-practice action validation passed.\n";


### PR DESCRIPTION
## Summary

- Reject Vulnerability Protection rule actions that are not listed in the active best-practice JSON definition.
- Correct the final VP validation gate to use the computed action result instead of the non-empty configured action string.
- Add a focused regression test covering accepted `reset-both`, `drop`, and `block-ip` actions and rejecting `alert`.

## Root cause

The profile-wide VP evaluator set `$action_bp` to `true` when an action did not match a configured best-practice action. It then tested `$action_check` rather than `$action_bp`, allowing `alert` to pass whenever packet-capture validation succeeded.

## Validation

```bash
php tests/test_vulnerability_best_practice.php
```

Result: `Vulnerability Protection best-practice action validation passed.`